### PR TITLE
Phase 7: notation layer (compact + JSON, file I/O, auto-detect)

### DIFF
--- a/src/chess4d/notation/__init__.py
+++ b/src/chess4d/notation/__init__.py
@@ -1,0 +1,323 @@
+"""chess4d notation layer (Phase 7).
+
+Serialization formats for moves, positions, and games:
+
+* :mod:`chess4d.notation.compact` — human-readable coordinate notation
+  (Format A). Designed to be eyeballable like a chess scoresheet while
+  being honest about 4D coordinates.
+* :mod:`chess4d.notation.json_format` — machine-readable JSON for
+  tooling and interchange (Format B).
+
+Neither Oana & Chiru nor any other published 4D-chess implementation
+ships a notation format; these are the reference formats for Python
+tooling around the chess4d package.
+
+Public API
+----------
+Format-specific parse/render helpers live in the two submodules
+(``parse_compact_move``/``render_compact_move``, ``parse_json_move``/
+``render_json_move``, plus ``_position`` and ``_game`` variants).
+
+File I/O lives here on the package root:
+
+* :func:`read_game_file` / :func:`write_game_file` — games on disk.
+* :func:`read_position_file` / :func:`write_position_file` —
+  standalone positions on disk.
+
+File format is inferred from extension:
+
+* ``.c4d`` — compact game
+* ``.c4dpos`` — compact position
+* ``.json`` — JSON game or JSON position (parser tells the two apart
+  from the object's top-level keys: ``{"moves": ...}`` is a game,
+  ``{"placements": ...}`` is a position).
+
+Pass an explicit ``format="compact"`` or ``format="json"`` to override
+extension-based inference.
+
+All parsers raise :class:`NotationError` (a :class:`ValueError`
+subclass) for syntactic failures. Semantic validation — "is this a
+legal move in the current state" — is not the notation layer's job;
+that lives on :meth:`chess4d.GameState.push`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from chess4d.notation.compact import (
+    parse_compact_game,
+    parse_compact_move,
+    parse_compact_position,
+    render_compact_game,
+    render_compact_move,
+    render_compact_position,
+)
+from chess4d.notation.errors import NotationError
+from chess4d.notation.json_format import (
+    parse_json_game,
+    parse_json_move,
+    parse_json_position,
+    render_json_game,
+    render_json_move,
+    render_json_position,
+)
+from chess4d.state import GameState
+from chess4d.types import Move4D
+
+_Format = Literal["compact", "json"]
+
+
+_EXT_FORMAT: dict[str, tuple[_Format, str]] = {
+    ".c4d": ("compact", "game"),
+    ".c4dpos": ("compact", "position"),
+    ".json": ("json", "either"),
+}
+
+
+def _detect_format(s: str) -> _Format:
+    """Infer the format from a serialized string's leading character.
+
+    A string whose first non-whitespace character is ``{`` is JSON;
+    anything else is compact. JSON strings starting with ``[`` or a
+    scalar are rejected by the underlying parser (notation payloads are
+    always objects), so this heuristic is safe.
+    """
+    for ch in s:
+        if ch.isspace():
+            continue
+        return "json" if ch == "{" else "compact"
+    # All-whitespace input: defer to compact, whose parser will raise
+    # a specific "no header / empty move" error.
+    return "compact"
+
+
+def _validate_format(format: _Format) -> None:
+    if format not in ("compact", "json"):
+        raise NotationError(
+            f"format must be 'compact' or 'json', got {format!r}"
+        )
+
+
+def _format_from_path(path: Path) -> _Format:
+    """Infer ``"compact"`` or ``"json"`` from a file path's extension.
+
+    Raises :class:`NotationError` if the extension is not one of the
+    three recognized suffixes.
+    """
+    suffix = path.suffix.lower()
+    if suffix not in _EXT_FORMAT:
+        raise NotationError(
+            f"cannot infer notation format from extension {suffix!r}; "
+            f"expected one of {sorted(_EXT_FORMAT)!r} or pass an explicit "
+            "format= argument"
+        )
+    return _EXT_FORMAT[suffix][0]
+
+
+def _resolve_format(path: Path, format: _Format | None) -> _Format:
+    if format is not None:
+        _validate_format(format)
+        return format
+    return _format_from_path(path)
+
+
+# Top-level auto-detect API (Phase 7E) --------------------------------------
+
+
+def parse_move(s: str, *, format: _Format | None = None) -> Move4D:
+    """Parse a move string. Auto-detects compact vs JSON if ``format`` is None.
+
+    Detection uses the first non-whitespace character: ``{`` selects
+    JSON, anything else selects compact. Pass ``format=`` to skip
+    detection.
+    """
+    if format is None:
+        format = _detect_format(s)
+    else:
+        _validate_format(format)
+    if format == "json":
+        return parse_json_move(s)
+    return parse_compact_move(s)
+
+
+def render_move(
+    m: Move4D,
+    *,
+    format: _Format = "compact",
+    is_capture: bool = False,
+) -> str:
+    """Render a move to the chosen format (default compact).
+
+    ``is_capture`` only affects the compact format — it selects the
+    ``x`` separator for ordinary capturing moves. JSON carries no
+    capture marker so the flag is ignored there.
+    """
+    _validate_format(format)
+    if format == "json":
+        return render_json_move(m)
+    return render_compact_move(m, is_capture=is_capture)
+
+
+def parse_position(s: str, *, format: _Format | None = None) -> GameState:
+    """Parse a position string. Auto-detects compact vs JSON if ``format`` is None."""
+    if format is None:
+        format = _detect_format(s)
+    else:
+        _validate_format(format)
+    if format == "json":
+        return parse_json_position(s)
+    return parse_compact_position(s)
+
+
+def render_position(gs: GameState, *, format: _Format = "compact") -> str:
+    """Render a position to the chosen format (default compact)."""
+    _validate_format(format)
+    if format == "json":
+        return render_json_position(gs)
+    return render_compact_position(gs)
+
+
+def parse_game(
+    s: str, *, format: _Format | None = None
+) -> tuple[GameState, list[Move4D]]:
+    """Parse a game string. Auto-detects compact vs JSON if ``format`` is None.
+
+    Returns ``(start_state, move_list)`` — the caller is responsible
+    for replaying the moves onto ``start_state`` to reach the end
+    position.
+    """
+    if format is None:
+        format = _detect_format(s)
+    else:
+        _validate_format(format)
+    if format == "json":
+        return parse_json_game(s)
+    return parse_compact_game(s)
+
+
+def render_game(
+    start: GameState,
+    moves: list[Move4D],
+    *,
+    format: _Format = "compact",
+    force_start: bool = False,
+) -> str:
+    """Render a game to the chosen format (default compact).
+
+    ``force_start`` includes the start position even when it equals
+    :func:`chess4d.startpos.initial_position`; otherwise the position
+    block is omitted and the parser reconstructs the default start.
+    """
+    _validate_format(format)
+    if format == "json":
+        return render_json_game(start, moves, force_start=force_start)
+    return render_compact_game(start, moves, force_start=force_start)
+
+
+def read_game_file(
+    path: Path | str, *, format: _Format | None = None
+) -> tuple[GameState, list[Move4D]]:
+    """Read a game file from disk and parse it.
+
+    The file's format defaults to whatever the extension implies
+    (``.c4d`` / ``.json``); pass ``format=`` to override. UTF-8 is used
+    unconditionally — chess notation is ASCII-only but the file itself
+    may carry an encoding declaration that Python's ``json`` module
+    handles silently.
+    """
+    p = Path(path)
+    fmt = _resolve_format(p, format)
+    text = p.read_text(encoding="utf-8")
+    if fmt == "compact":
+        return parse_compact_game(text)
+    return parse_json_game(text)
+
+
+def write_game_file(
+    path: Path | str,
+    start: GameState,
+    moves: list[Move4D],
+    *,
+    format: _Format | None = None,
+    force_start: bool = False,
+) -> None:
+    """Write a game to disk.
+
+    ``force_start`` passes through to the underlying renderer: pass
+    ``True`` to include the start position even when it equals
+    :func:`chess4d.startpos.initial_position`. JSON games are written
+    pretty-printed (``indent=2``) for file readability; the inline
+    :func:`render_json_game` defaults to single-line.
+    """
+    p = Path(path)
+    fmt = _resolve_format(p, format)
+    if fmt == "compact":
+        text = render_compact_game(start, moves, force_start=force_start)
+    else:
+        text = render_json_game(start, moves, force_start=force_start, indent=2)
+        if not text.endswith("\n"):
+            text += "\n"
+    p.write_text(text, encoding="utf-8")
+
+
+def read_position_file(
+    path: Path | str, *, format: _Format | None = None
+) -> GameState:
+    """Read a standalone-position file from disk."""
+    p = Path(path)
+    fmt = _resolve_format(p, format)
+    text = p.read_text(encoding="utf-8")
+    if fmt == "compact":
+        return parse_compact_position(text)
+    return parse_json_position(text)
+
+
+def write_position_file(
+    path: Path | str,
+    gs: GameState,
+    *,
+    format: _Format | None = None,
+) -> None:
+    """Write a standalone :class:`GameState` to disk as a position file."""
+    p = Path(path)
+    fmt = _resolve_format(p, format)
+    if fmt == "compact":
+        text = render_compact_position(gs)
+        if not text.endswith("\n"):
+            text += "\n"
+    else:
+        import json as _json
+
+        from chess4d.notation.json_format import position_to_obj
+
+        text = _json.dumps(position_to_obj(gs), indent=2) + "\n"
+    p.write_text(text, encoding="utf-8")
+
+
+__all__ = [
+    "NotationError",
+    "parse_compact_game",
+    "parse_compact_move",
+    "parse_compact_position",
+    "parse_game",
+    "parse_json_game",
+    "parse_json_move",
+    "parse_json_position",
+    "parse_move",
+    "parse_position",
+    "read_game_file",
+    "read_position_file",
+    "render_compact_game",
+    "render_compact_move",
+    "render_compact_position",
+    "render_game",
+    "render_json_game",
+    "render_json_move",
+    "render_json_position",
+    "render_move",
+    "render_position",
+    "write_game_file",
+    "write_position_file",
+]

--- a/src/chess4d/notation/compact.py
+++ b/src/chess4d/notation/compact.py
@@ -1,0 +1,766 @@
+"""Phase 7 Format A — compact (human-readable) notation.
+
+Coordinate encoding
+-------------------
+A square is four characters in ``(x, y, z, w)`` order:
+
+* x-axis: lowercase letter ``a``–``h`` (``a`` ↔ 0, ``h`` ↔ 7)
+* y-axis: digit ``1``–``8`` (``1`` ↔ 0, ``8`` ↔ 7)
+* z-axis: lowercase letter ``a``–``h``
+* w-axis: digit ``1``–``8``
+
+The letter/digit/letter/digit pattern is strictly positional: ``a1c4``
+is unambiguously ``Square4D(x=0, y=0, z=2, w=3)``. Because coordinate
+letters are drawn from ``a``–``h`` only, the letter ``x`` never appears
+inside a coordinate — so ``x`` is a safe capture marker between two
+coordinates and can never be confused for part of either.
+
+Move grammar
+------------
+::
+
+    <move>       ::= <ordinary> | <capture> | <castling> | <ep>
+    <ordinary>   ::= <from>-<to>[=<promo>]
+    <capture>    ::= <from>x<to>[=<promo>]
+    <castling>   ::= ("O-O" | "O-O-O" | "o-o" | "o-o-o") "@" <slice>
+    <ep>         ::= <from>x<to>"ep"
+    <from>, <to> ::= 4-character coordinate
+    <slice>      ::= 2-character (z, w) coordinate
+    <promo>      ::= "Q" | "R" | "B" | "N"
+
+The capture marker (``x``) is informational only — the parser accepts
+either ``-`` or ``x`` between the two coordinates and records nothing
+about capture status on the returned :class:`~chess4d.Move4D`. The
+renderer emits ``x`` when the caller flags the move as a capture.
+
+Castling encodes its color by case: uppercase ``O`` for white,
+lowercase ``o`` for black. This matches the uppercase/lowercase piece
+convention used by the position format (7B) and keeps
+:func:`parse_compact_move` self-contained — no side-to-move context
+needs to be threaded through to resolve castling moves.
+
+Promotion characters are case-sensitive: ``Q``/``R``/``B``/``N`` only.
+Lowercase promotion letters are rejected.
+
+Position grammar
+----------------
+A position file begins with a single header line and is followed by
+zero or more slice lines (one per non-empty ``(z, w)``-slice)::
+
+    <header>      ::= <side> " " <castling> " " <ep> " " <halfmove>
+    <slice-line>  ::= <slice-key> ": " <rank0> "/" <rank1> "/" ... "/" <rank7>
+    <slice-key>   ::= 2-character (z, w) coordinate
+    <rank>        ::= 8 characters (x = 0..7) from the piece-char set
+    <side>        ::= "w" | "b"   (case-insensitive on parse)
+    <castling>    ::= "-" | <right> ("," <right>)*
+    <right>       ::= <color_ch> <slice-key> <side_ch>
+    <color_ch>    ::= "W" | "B"
+    <side_ch>     ::= "K" | "Q"
+    <ep>          ::= "-" | 4-character coordinate
+    <halfmove>    ::= decimal integer (unsigned)
+
+Rank order within a slice is ascending ``y`` — ``rank0`` is the white
+back rank (``y = 0``), ``rank7`` is the black back rank (``y = 7``).
+Omitted slices are empty by definition; a slice with at least one
+piece must be listed in full. The renderer emits slices in
+``(z, w)``-major order and never emits empty slices; the parser
+accepts slices in any order and accepts an explicit ``<slice-key>:
+empty`` line as a synonym for omission.
+
+Piece characters
+~~~~~~~~~~~~~~~~
+
+============  ==================================
+``.``         empty square
+``R/N/B/Q/K`` white rook / knight / bishop / queen / king
+``r/n/b/q/k`` black (same)
+``Y``         white Y-oriented pawn
+``W``         white W-oriented pawn
+``y``         black Y-oriented pawn
+``w``         black W-oriented pawn
+============  ==================================
+
+All pawns must specify their axis via ``Y``/``W``/``y``/``w``; a plain
+``P``/``p`` is not accepted. Promoted pieces drop their pawn marker and
+use the new piece's letter.
+"""
+
+from __future__ import annotations
+
+from chess4d.board import Board4D
+from chess4d.state import GameState
+from chess4d.types import (
+    BOARD_SIZE,
+    CastleSide,
+    CastlingRight,
+    Color,
+    Move4D,
+    PawnAxis,
+    Piece,
+    PieceType,
+    Square4D,
+)
+
+from chess4d.notation.errors import NotationError
+
+
+_LETTER_MIN = "a"
+_LETTER_MAX = "h"
+_DIGIT_MIN = "1"
+_DIGIT_MAX = "8"
+
+_PROMOTION_BY_CHAR: dict[str, PieceType] = {
+    "Q": PieceType.QUEEN,
+    "R": PieceType.ROOK,
+    "B": PieceType.BISHOP,
+    "N": PieceType.KNIGHT,
+}
+
+_CHAR_BY_PROMOTION: dict[PieceType, str] = {v: k for k, v in _PROMOTION_BY_CHAR.items()}
+
+
+def _parse_letter(ch: str, field: str) -> int:
+    """Parse a single ``a``-``h`` character to its 0-based coordinate."""
+    if len(ch) != 1 or not (_LETTER_MIN <= ch <= _LETTER_MAX):
+        raise NotationError(
+            f"expected letter a-h for {field}, got {ch!r}"
+        )
+    return ord(ch) - ord(_LETTER_MIN)
+
+
+def _parse_digit(ch: str, field: str) -> int:
+    """Parse a single ``1``-``8`` character to its 0-based coordinate."""
+    if len(ch) != 1 or not (_DIGIT_MIN <= ch <= _DIGIT_MAX):
+        raise NotationError(
+            f"expected digit 1-8 for {field}, got {ch!r}"
+        )
+    return int(ch) - 1
+
+
+def _parse_coord(s: str, field: str) -> Square4D:
+    """Parse a 4-character coordinate into a :class:`~chess4d.Square4D`."""
+    if len(s) != 4:
+        raise NotationError(
+            f"{field} coordinate must be exactly 4 characters, got {s!r}"
+        )
+    return Square4D(
+        _parse_letter(s[0], f"{field}.x"),
+        _parse_digit(s[1], f"{field}.y"),
+        _parse_letter(s[2], f"{field}.z"),
+        _parse_digit(s[3], f"{field}.w"),
+    )
+
+
+def _render_letter(v: int) -> str:
+    return chr(ord(_LETTER_MIN) + v)
+
+
+def _render_digit(v: int) -> str:
+    return str(v + 1)
+
+
+def _render_coord(sq: Square4D) -> str:
+    """Render a :class:`~chess4d.Square4D` as a 4-character coordinate."""
+    return (
+        _render_letter(sq.x)
+        + _render_digit(sq.y)
+        + _render_letter(sq.z)
+        + _render_digit(sq.w)
+    )
+
+
+def _parse_slice(s: str) -> tuple[int, int]:
+    """Parse a 2-character ``(z, w)`` coordinate."""
+    if len(s) != 2:
+        raise NotationError(
+            f"slice must be exactly 2 characters, got {s!r}"
+        )
+    return _parse_letter(s[0], "slice.z"), _parse_digit(s[1], "slice.w")
+
+
+def _render_slice(z: int, w: int) -> str:
+    return _render_letter(z) + _render_digit(w)
+
+
+def _parse_castle(s: str) -> Move4D:
+    """Parse a castling move (e.g. ``O-O@c4``, ``o-o-o@d4``)."""
+    at = s.find("@")
+    if at < 0:
+        raise NotationError(
+            f"castling move missing '@<slice>' suffix: {s!r}"
+        )
+    castle_part = s[:at]
+    slice_part = s[at + 1:]
+    if castle_part == "O-O":
+        color, side = Color.WHITE, CastleSide.KINGSIDE
+    elif castle_part == "O-O-O":
+        color, side = Color.WHITE, CastleSide.QUEENSIDE
+    elif castle_part == "o-o":
+        color, side = Color.BLACK, CastleSide.KINGSIDE
+    elif castle_part == "o-o-o":
+        color, side = Color.BLACK, CastleSide.QUEENSIDE
+    else:
+        raise NotationError(
+            f"invalid castling token {castle_part!r}: "
+            "expected 'O-O', 'O-O-O', 'o-o', or 'o-o-o'"
+        )
+    z, w = _parse_slice(slice_part)
+    back_y = 0 if color is Color.WHITE else BOARD_SIZE - 1
+    to_x = 6 if side is CastleSide.KINGSIDE else 2
+    return Move4D(
+        from_sq=Square4D(4, back_y, z, w),
+        to_sq=Square4D(to_x, back_y, z, w),
+        is_castling=True,
+    )
+
+
+def _render_castle(m: Move4D) -> str:
+    """Render a castling :class:`~chess4d.Move4D` as compact notation."""
+    if m.from_sq.x != 4 or m.to_sq.x not in (2, 6):
+        raise ValueError(
+            f"cannot render castling move with x={m.from_sq.x}->{m.to_sq.x}; "
+            "expected from.x=4 and to.x in (2, 6)"
+        )
+    if m.from_sq.y not in (0, BOARD_SIZE - 1):
+        raise ValueError(
+            f"cannot render castling move with from.y={m.from_sq.y}; "
+            f"expected 0 (white) or {BOARD_SIZE - 1} (black)"
+        )
+    if (m.from_sq.y, m.from_sq.z, m.from_sq.w) != (m.to_sq.y, m.to_sq.z, m.to_sq.w):
+        raise ValueError(
+            "cannot render castling move that leaves its (y, z, w) slice"
+        )
+    is_white = m.from_sq.y == 0
+    kingside = m.to_sq.x == 6
+    o = "O" if is_white else "o"
+    base = f"{o}-{o}" if kingside else f"{o}-{o}-{o}"
+    return f"{base}@{_render_slice(m.from_sq.z, m.from_sq.w)}"
+
+
+def parse_compact_move(s: str) -> Move4D:
+    """Parse a compact-notation move string into a :class:`~chess4d.Move4D`.
+
+    Accepts any of the four grammar branches (ordinary, capture,
+    castling, en passant). Raises :class:`NotationError` for any
+    syntactic problem; the error message names the failing field.
+
+    This function performs *syntactic* validation only. It does not
+    check that the resulting move is legal in any particular position,
+    nor that (for instance) a promotion target is on the terminal rank.
+    Semantic validation belongs to :meth:`chess4d.GameState.push`.
+    """
+    if not s:
+        raise NotationError("empty move string")
+    if s[0] in ("O", "o"):
+        return _parse_castle(s)
+    if len(s) < 9:
+        raise NotationError(
+            f"move too short: {s!r} (need at least 9 characters for "
+            "'<from><sep><to>')"
+        )
+    from_sq = _parse_coord(s[0:4], "from")
+    sep = s[4]
+    if sep not in ("-", "x"):
+        raise NotationError(
+            f"expected '-' or 'x' separator at position 4, got {sep!r} in {s!r}"
+        )
+    to_sq = _parse_coord(s[5:9], "to")
+    tail = s[9:]
+    promotion: PieceType | None = None
+    is_en_passant = False
+    if tail == "":
+        pass
+    elif tail == "ep":
+        if sep != "x":
+            raise NotationError(
+                f"en-passant suffix 'ep' requires 'x' capture marker, "
+                f"found '-' in {s!r}"
+            )
+        is_en_passant = True
+    elif tail.startswith("=") and len(tail) == 2:
+        promo_char = tail[1]
+        if promo_char not in _PROMOTION_BY_CHAR:
+            raise NotationError(
+                f"expected promotion piece Q/R/B/N, got {promo_char!r} in {s!r}"
+            )
+        promotion = _PROMOTION_BY_CHAR[promo_char]
+    else:
+        raise NotationError(
+            f"unexpected trailing characters {tail!r} after move body in {s!r}"
+        )
+    return Move4D(
+        from_sq=from_sq,
+        to_sq=to_sq,
+        promotion=promotion,
+        is_en_passant=is_en_passant,
+    )
+
+
+def render_compact_move(m: Move4D, *, is_capture: bool = False) -> str:
+    """Render a :class:`~chess4d.Move4D` as a compact-notation string.
+
+    The ``is_capture`` flag selects the ``x`` separator for ordinary
+    capturing moves; en-passant captures always render with ``x``
+    regardless of the flag. For castling moves the flag is ignored.
+    The flag is the caller's responsibility: a move's :class:`Move4D`
+    does not carry the captured piece's identity, so the caller must
+    track capture status externally (typically by looking at the
+    destination square on the pre-move board).
+    """
+    if m.is_castling:
+        return _render_castle(m)
+    sep = "x" if (is_capture or m.is_en_passant) else "-"
+    core = f"{_render_coord(m.from_sq)}{sep}{_render_coord(m.to_sq)}"
+    if m.is_en_passant:
+        return core + "ep"
+    if m.promotion is not None:
+        return core + "=" + _CHAR_BY_PROMOTION[m.promotion]
+    return core
+
+
+# Position notation ----------------------------------------------------------
+
+_PIECE_BY_CHAR: dict[str, Piece] = {
+    "R": Piece(Color.WHITE, PieceType.ROOK),
+    "N": Piece(Color.WHITE, PieceType.KNIGHT),
+    "B": Piece(Color.WHITE, PieceType.BISHOP),
+    "Q": Piece(Color.WHITE, PieceType.QUEEN),
+    "K": Piece(Color.WHITE, PieceType.KING),
+    "Y": Piece(Color.WHITE, PieceType.PAWN, PawnAxis.Y),
+    "W": Piece(Color.WHITE, PieceType.PAWN, PawnAxis.W),
+    "r": Piece(Color.BLACK, PieceType.ROOK),
+    "n": Piece(Color.BLACK, PieceType.KNIGHT),
+    "b": Piece(Color.BLACK, PieceType.BISHOP),
+    "q": Piece(Color.BLACK, PieceType.QUEEN),
+    "k": Piece(Color.BLACK, PieceType.KING),
+    "y": Piece(Color.BLACK, PieceType.PAWN, PawnAxis.Y),
+    "w": Piece(Color.BLACK, PieceType.PAWN, PawnAxis.W),
+}
+
+_CHAR_BY_PIECE: dict[Piece, str] = {v: k for k, v in _PIECE_BY_CHAR.items()}
+
+_EMPTY_CHAR = "."
+
+
+def _parse_piece_char(ch: str, where: str) -> Piece | None:
+    """Return the :class:`Piece` for a rank character, or ``None`` for empty."""
+    if ch == _EMPTY_CHAR:
+        return None
+    piece = _PIECE_BY_CHAR.get(ch)
+    if piece is None:
+        raise NotationError(
+            f"unknown piece character {ch!r} at {where} "
+            f"(expected one of '{_EMPTY_CHAR}' or R/N/B/Q/K/Y/W/r/n/b/q/k/y/w)"
+        )
+    return piece
+
+
+def _render_piece(piece: Piece | None) -> str:
+    if piece is None:
+        return _EMPTY_CHAR
+    return _CHAR_BY_PIECE[piece]
+
+
+def _parse_castling_rights(s: str) -> frozenset[CastlingRight]:
+    """Parse the header ``<castling>`` token into a castling-rights set."""
+    if s == "-":
+        return frozenset()
+    rights: set[CastlingRight] = set()
+    for token in s.split(","):
+        if len(token) != 4:
+            raise NotationError(
+                f"castling-right token must be 4 characters (color+slice+side), "
+                f"got {token!r}"
+            )
+        color_ch = token[0]
+        if color_ch == "W":
+            color = Color.WHITE
+        elif color_ch == "B":
+            color = Color.BLACK
+        else:
+            raise NotationError(
+                f"castling-right color must be 'W' or 'B', got {color_ch!r} "
+                f"in {token!r}"
+            )
+        z, w = _parse_slice(token[1:3])
+        side_ch = token[3]
+        if side_ch == "K":
+            side = CastleSide.KINGSIDE
+        elif side_ch == "Q":
+            side = CastleSide.QUEENSIDE
+        else:
+            raise NotationError(
+                f"castling-right side must be 'K' or 'Q', got {side_ch!r} "
+                f"in {token!r}"
+            )
+        right: CastlingRight = (color, z, w, side)
+        if right in rights:
+            raise NotationError(
+                f"duplicate castling right {token!r} in rights string"
+            )
+        rights.add(right)
+    return frozenset(rights)
+
+
+def _render_castling_rights(rights: frozenset[CastlingRight]) -> str:
+    """Render the castling-rights set in canonical ``(color, z, w, side)`` order."""
+    if not rights:
+        return "-"
+    ordered = sorted(rights, key=lambda r: (int(r[0]), r[1], r[2], int(r[3])))
+    parts: list[str] = []
+    for color, z, w, side in ordered:
+        color_ch = "W" if color is Color.WHITE else "B"
+        side_ch = "K" if side is CastleSide.KINGSIDE else "Q"
+        parts.append(f"{color_ch}{_render_slice(z, w)}{side_ch}")
+    return ",".join(parts)
+
+
+def _parse_rank_line(s: str, z: int, w: int, y: int) -> list[tuple[Square4D, Piece]]:
+    """Parse an 8-character rank line into ``(square, piece)`` placements."""
+    if len(s) != BOARD_SIZE:
+        raise NotationError(
+            f"rank line for slice ({z}, {w}) y={y} must be {BOARD_SIZE} characters, "
+            f"got {len(s)} in {s!r}"
+        )
+    out: list[tuple[Square4D, Piece]] = []
+    for x, ch in enumerate(s):
+        piece = _parse_piece_char(ch, f"slice ({z}, {w}) y={y} x={x}")
+        if piece is not None:
+            out.append((Square4D(x, y, z, w), piece))
+    return out
+
+
+def _render_rank_line(board: Board4D, z: int, w: int, y: int) -> str:
+    chars: list[str] = []
+    for x in range(BOARD_SIZE):
+        chars.append(_render_piece(board.occupant(Square4D(x, y, z, w))))
+    return "".join(chars)
+
+
+def _slice_is_empty(board: Board4D, z: int, w: int) -> bool:
+    for y in range(BOARD_SIZE):
+        for x in range(BOARD_SIZE):
+            if board.occupant(Square4D(x, y, z, w)) is not None:
+                return False
+    return True
+
+
+def _reconstruct_ep(
+    board: Board4D, ep_target: Square4D, side_to_move: Color
+) -> tuple[Square4D, PawnAxis]:
+    """Derive ``(ep_victim, ep_axis)`` from an ep-target coordinate.
+
+    The victim of an en-passant capture is the pawn whose 2-step
+    created the target — it sits one square past ``ep_target`` along
+    its own ``pawn_axis``, on the side-to-move's enemy. There is at
+    most one such pawn for a well-formed position (produced by a
+    single 2-step move from the previous ply); the parser raises
+    :class:`NotationError` otherwise.
+    """
+    enemy = Color(1 - side_to_move)
+    candidates: list[tuple[Square4D, PawnAxis]] = []
+    for axis in (PawnAxis.Y, PawnAxis.W):
+        axis_idx = int(axis)
+        for step in (-1, 1):
+            coords = list(ep_target)
+            coords[axis_idx] += step
+            victim_sq = Square4D(coords[0], coords[1], coords[2], coords[3])
+            if not victim_sq.in_bounds():
+                continue
+            piece = board.occupant(victim_sq)
+            if piece is None or piece.piece_type is not PieceType.PAWN:
+                continue
+            if piece.color is not enemy:
+                continue
+            if piece.pawn_axis is not axis:
+                continue
+            candidates.append((victim_sq, axis))
+    if not candidates:
+        raise NotationError(
+            f"ep_target {_render_coord(ep_target)} has no adjacent enemy pawn "
+            "whose axis could have produced it"
+        )
+    if len(candidates) > 1:
+        raise NotationError(
+            f"ep_target {_render_coord(ep_target)} is ambiguous: "
+            f"{len(candidates)} candidate victims exist"
+        )
+    return candidates[0]
+
+
+def _parse_header(
+    line: str,
+) -> tuple[Color, frozenset[CastlingRight], Square4D | None, int]:
+    """Parse the header line into ``(side, rights, ep_target, halfmove)``."""
+    parts = line.split()
+    if len(parts) != 4:
+        raise NotationError(
+            f"header must have 4 space-separated fields "
+            f"(side, castling, ep, halfmove), got {len(parts)} in {line!r}"
+        )
+    side_tok, castle_tok, ep_tok, half_tok = parts
+    side_lower = side_tok.lower()
+    if side_lower == "w":
+        side = Color.WHITE
+    elif side_lower == "b":
+        side = Color.BLACK
+    else:
+        raise NotationError(
+            f"side-to-move must be 'w' or 'b', got {side_tok!r}"
+        )
+    rights = _parse_castling_rights(castle_tok)
+    ep_target: Square4D | None
+    if ep_tok == "-":
+        ep_target = None
+    else:
+        ep_target = _parse_coord(ep_tok, "ep")
+    try:
+        halfmove = int(half_tok)
+    except ValueError as exc:
+        raise NotationError(
+            f"halfmove clock must be a decimal integer, got {half_tok!r}"
+        ) from exc
+    if halfmove < 0:
+        raise NotationError(
+            f"halfmove clock must be non-negative, got {halfmove}"
+        )
+    return side, rights, ep_target, halfmove
+
+
+def _render_header(gs: GameState) -> str:
+    side_ch = "w" if gs.side_to_move is Color.WHITE else "b"
+    castle = _render_castling_rights(gs.castling_rights)
+    ep = _render_coord(gs.ep_target) if gs.ep_target is not None else "-"
+    return f"{side_ch} {castle} {ep} {gs.halfmove_clock}"
+
+
+def parse_compact_position(s: str) -> GameState:
+    """Parse a compact-notation position into a :class:`~chess4d.GameState`.
+
+    The input may contain blank lines between the header and any slice
+    line, and trailing whitespace on any line is ignored. An explicit
+    ``<slice-key>: empty`` marker is accepted as a synonym for "slice
+    omitted" — both produce the same empty ``(z, w)`` slab.
+
+    Ep-state reconstruction: the header carries only ``ep_target``; the
+    parser derives ``ep_victim`` and ``ep_axis`` from the board (see
+    :func:`_reconstruct_ep`). If the ep target is present but no enemy
+    pawn is adjacent along a single axis, the parse fails.
+    """
+    lines = [ln.rstrip() for ln in s.splitlines()]
+    lines = [ln for ln in lines if ln.strip() != ""]
+    if not lines:
+        raise NotationError("position is empty (no header line)")
+    side, rights, ep_target, halfmove = _parse_header(lines[0])
+    board = Board4D()
+    seen_slices: set[tuple[int, int]] = set()
+    for raw in lines[1:]:
+        key_sep = raw.find(":")
+        if key_sep < 0:
+            raise NotationError(
+                f"slice line missing ':' separator: {raw!r}"
+            )
+        slice_key = raw[:key_sep].strip()
+        body = raw[key_sep + 1:].strip()
+        if len(slice_key) != 2:
+            raise NotationError(
+                f"slice key must be 2 characters, got {slice_key!r} in {raw!r}"
+            )
+        z, w = _parse_slice(slice_key)
+        if (z, w) in seen_slices:
+            raise NotationError(
+                f"slice ({z}, {w}) listed more than once"
+            )
+        seen_slices.add((z, w))
+        if body == "empty":
+            continue
+        rank_lines = body.split("/")
+        if len(rank_lines) != BOARD_SIZE:
+            raise NotationError(
+                f"slice ({z}, {w}) must have {BOARD_SIZE} ranks separated by '/', "
+                f"got {len(rank_lines)} in {body!r}"
+            )
+        for y, rank in enumerate(rank_lines):
+            for sq, piece in _parse_rank_line(rank, z, w, y):
+                board.place(sq, piece)
+    ep_victim: Square4D | None = None
+    ep_axis: PawnAxis | None = None
+    if ep_target is not None:
+        ep_victim, ep_axis = _reconstruct_ep(board, ep_target, side)
+    return GameState(
+        board=board,
+        side_to_move=side,
+        castling_rights=rights,
+        ep_target=ep_target,
+        ep_victim=ep_victim,
+        ep_axis=ep_axis,
+        halfmove_clock=halfmove,
+    )
+
+
+def render_compact_position(gs: GameState) -> str:
+    """Render a :class:`~chess4d.GameState` as compact-notation text.
+
+    The output is the header line followed by one line per non-empty
+    ``(z, w)``-slice, in ``(z, w)``-major order. Slices that contain no
+    pieces are omitted — the parser treats omission as empty, and for
+    a fully-empty board the rendered output is just the header line.
+    """
+    board = gs.board
+    out: list[str] = [_render_header(gs)]
+    for z in range(BOARD_SIZE):
+        for w in range(BOARD_SIZE):
+            if _slice_is_empty(board, z, w):
+                continue
+            ranks = [_render_rank_line(board, z, w, y) for y in range(BOARD_SIZE)]
+            out.append(f"{_render_slice(z, w)}: {'/'.join(ranks)}")
+    return "\n".join(out)
+
+
+# Game notation --------------------------------------------------------------
+
+
+def _strip_comments_and_blanks(s: str) -> list[str]:
+    """Return non-blank, non-comment lines ``rstrip``'d of trailing space.
+
+    Lines whose first non-whitespace character is ``#`` are treated as
+    comments; blank lines (whitespace-only) are skipped. Any other
+    leading whitespace is preserved so that callers can still see the
+    shape of the line for downstream parsing.
+    """
+    out: list[str] = []
+    for raw in s.splitlines():
+        trimmed = raw.rstrip()
+        if trimmed.strip() == "":
+            continue
+        if trimmed.lstrip().startswith("#"):
+            continue
+        out.append(trimmed)
+    return out
+
+
+def _line_is_position_header(line: str) -> bool:
+    """True iff ``line`` looks like a compact-position header line.
+
+    A compact-position header has exactly four space-separated tokens
+    and its side-to-move token is a single ``w``/``b`` (case-insensitive).
+    Compact moves never have whitespace inside a token, so this test
+    cleanly distinguishes the two without trying a parse.
+    """
+    parts = line.strip().split()
+    if len(parts) != 4:
+        return False
+    return parts[0] in ("w", "b", "W", "B")
+
+
+def _line_is_slice_body(line: str) -> bool:
+    """True iff ``line`` looks like a compact-position slice-body line.
+
+    Slice lines are ``<z><w>: <rank>/.../<rank>`` or the shorthand
+    ``<z><w>: empty`` — a 2-char key (letter + digit) followed by
+    ``:``. Compact moves never contain ``:``.
+    """
+    if ":" not in line:
+        return False
+    key = line.split(":", 1)[0].strip()
+    if len(key) != 2:
+        return False
+    return ("a" <= key[0] <= "h") and ("1" <= key[1] <= "8")
+
+
+def parse_compact_game(s: str) -> tuple[GameState, list[Move4D]]:
+    """Parse a compact-game string into ``(start_state, move_list)``.
+
+    A compact game is:
+
+    * Zero or more ``#``-prefixed comment lines (ignored) and blank
+      lines (ignored), interleaved anywhere.
+    * An optional start-position block — the header line plus any
+      consecutive slice-body lines. If the first non-comment line is
+      not a position header, the start defaults to
+      :func:`chess4d.startpos.initial_position`.
+    * Zero or more move lines, one compact move per line.
+
+    Moves are returned unreplayed: the caller is responsible for
+    advancing the returned ``start_state`` through the move list if a
+    post-game state is needed. Per-move parse errors are wrapped with
+    the move's 1-based index for diagnostics.
+    """
+    from chess4d.startpos import initial_position
+
+    meaningful = _strip_comments_and_blanks(s)
+    if not meaningful:
+        return initial_position(), []
+
+    if _line_is_position_header(meaningful[0]):
+        pos_lines = [meaningful[0]]
+        i = 1
+        while i < len(meaningful) and _line_is_slice_body(meaningful[i]):
+            pos_lines.append(meaningful[i])
+            i += 1
+        start = parse_compact_position("\n".join(pos_lines))
+        move_lines = meaningful[i:]
+    else:
+        start = initial_position()
+        move_lines = meaningful
+
+    moves: list[Move4D] = []
+    for idx, line in enumerate(move_lines, start=1):
+        try:
+            moves.append(parse_compact_move(line.strip()))
+        except NotationError as exc:
+            raise NotationError(
+                f"move #{idx} ({line.strip()!r}): {exc}"
+            ) from exc
+    return start, moves
+
+
+def render_compact_game(
+    start: GameState,
+    moves: list[Move4D],
+    *,
+    force_start: bool = False,
+) -> str:
+    """Render a ``(start, moves)`` game to a compact-game string.
+
+    If ``start`` is equivalent to :func:`chess4d.startpos.initial_position`
+    the position block is omitted — the parser defaults to
+    ``initial_position()`` when no header is present. Pass
+    ``force_start=True`` to always emit the position block (useful for
+    explicit round-trip tests).
+
+    The move separator (``-`` vs ``x``) is chosen by replaying ``moves``
+    onto a deep copy of ``start`` to determine whether each destination
+    was occupied pre-move. Replay uses the full legality pipeline; an
+    illegal move in the list will surface as
+    :class:`~chess4d.errors.IllegalMoveError`.
+    """
+    from copy import deepcopy
+
+    lines: list[str] = []
+    include_start = force_start or not _game_starts_from_initial(start)
+    if include_start:
+        lines.append(render_compact_position(start))
+
+    replay = deepcopy(start)
+    for m in moves:
+        is_capture = replay.board.occupant(m.to_sq) is not None
+        lines.append(render_compact_move(m, is_capture=is_capture))
+        replay.push(m)
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def _game_starts_from_initial(gs: GameState) -> bool:
+    """True iff ``gs`` is a freshly-built initial position."""
+    from chess4d.startpos import initial_position
+
+    ref = initial_position()
+    return (
+        gs.board == ref.board
+        and gs.side_to_move is ref.side_to_move
+        and gs.castling_rights == ref.castling_rights
+        and gs.ep_target == ref.ep_target
+        and gs.ep_victim == ref.ep_victim
+        and gs.ep_axis is ref.ep_axis
+        and gs.halfmove_clock == ref.halfmove_clock
+    )

--- a/src/chess4d/notation/errors.py
+++ b/src/chess4d/notation/errors.py
@@ -1,0 +1,19 @@
+"""Exceptions for the chess4d notation layer (Phase 7).
+
+Parsers in :mod:`chess4d.notation.compact` and
+:mod:`chess4d.notation.json_format` raise :class:`NotationError` for all
+syntactic failures. It is a subclass of :class:`ValueError` so that
+callers who only care about the general "bad input" shape can catch the
+stdlib type without importing this module.
+"""
+
+from __future__ import annotations
+
+
+class NotationError(ValueError):
+    """Raised when a notation parser rejects an input string.
+
+    Error messages include the offending input fragment and a short
+    description of what was expected. Parsers fail fast on the first
+    problem — they do not collect multiple errors into a single raise.
+    """

--- a/src/chess4d/notation/json_format.py
+++ b/src/chess4d/notation/json_format.py
@@ -1,0 +1,532 @@
+"""Phase 7 Format B — JSON (machine-readable) notation.
+
+The JSON format mirrors the in-memory shape of :class:`~chess4d.Move4D`
+and :class:`~chess4d.GameState` directly. Where the compact format
+collapses ep state into a single ``ep_target`` field and reconstructs
+victim/axis by scanning the board, the JSON format keeps all three
+fields (``ep_target``, ``ep_victim``, ``ep_axis``) explicit — JSON's
+job is interchange with external tools, not human editing.
+
+Move shape
+----------
+::
+
+    {
+      "from": [x, y, z, w],
+      "to":   [x, y, z, w],
+      "promotion": null | "QUEEN" | "ROOK" | "BISHOP" | "KNIGHT",
+      "is_castling":   bool,
+      "is_en_passant": bool
+    }
+
+``from``/``to`` are required. Boolean flags and ``promotion`` default
+as shown when omitted; unknown keys raise :class:`NotationError`.
+
+Position shape
+--------------
+::
+
+    {
+      "placements": [
+        {"square": [x, y, z, w],
+         "color":  "WHITE" | "BLACK",
+         "piece_type": "PAWN" | "KNIGHT" | "BISHOP" | "ROOK" | "QUEEN" | "KING",
+         "pawn_axis":  null | "Y" | "W"},
+        ...
+      ],
+      "side_to_move":   "WHITE" | "BLACK",
+      "castling_rights": [
+        {"color": "WHITE" | "BLACK",
+         "slice": [z, w],
+         "side":  "KINGSIDE" | "QUEENSIDE"},
+        ...
+      ],
+      "ep_target":  null | [x, y, z, w],
+      "ep_victim":  null | [x, y, z, w],
+      "ep_axis":    null | "Y" | "W",
+      "halfmove_clock": int
+    }
+
+Placement order within the ``placements`` array is not significant
+(renderer emits in canonical ``(x, y, z, w)`` order for stable output;
+parser accepts any order). Ep fields are all-or-nothing: either all
+three are ``null`` or all three are set.
+
+The :class:`GameState.position_history` field is deliberately not
+serialized — it is a runtime reconstruction from a move list, not part
+of the position's identity. A game's history lives in the 7D game
+format, replayed from ``start`` on parse.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+from chess4d.board import Board4D
+from chess4d.state import GameState
+from chess4d.types import (
+    BOARD_SIZE,
+    CastleSide,
+    CastlingRight,
+    Color,
+    Move4D,
+    PawnAxis,
+    Piece,
+    PieceType,
+    Square4D,
+)
+
+from chess4d.notation.errors import NotationError
+
+# Enum name maps -------------------------------------------------------------
+
+_COLOR_BY_NAME: dict[str, Color] = {c.name: c for c in Color}
+_PIECE_TYPE_BY_NAME: dict[str, PieceType] = {p.name: p for p in PieceType}
+_CASTLE_SIDE_BY_NAME: dict[str, CastleSide] = {s.name: s for s in CastleSide}
+_PAWN_AXIS_BY_NAME: dict[str, PawnAxis] = {a.name: a for a in PawnAxis}
+
+_PROMOTION_TYPES: frozenset[PieceType] = frozenset(
+    {PieceType.QUEEN, PieceType.ROOK, PieceType.BISHOP, PieceType.KNIGHT}
+)
+
+_MOVE_KEYS: frozenset[str] = frozenset(
+    {"from", "to", "promotion", "is_castling", "is_en_passant"}
+)
+_PLACEMENT_KEYS: frozenset[str] = frozenset(
+    {"square", "color", "piece_type", "pawn_axis"}
+)
+_CASTLING_RIGHT_KEYS: frozenset[str] = frozenset({"color", "slice", "side"})
+_POSITION_KEYS: frozenset[str] = frozenset(
+    {
+        "placements",
+        "side_to_move",
+        "castling_rights",
+        "ep_target",
+        "ep_victim",
+        "ep_axis",
+        "halfmove_clock",
+    }
+)
+
+
+def _ensure_object(v: Any, where: str) -> dict[str, Any]:
+    if not isinstance(v, dict):
+        raise NotationError(
+            f"{where} must be a JSON object, got {type(v).__name__}"
+        )
+    return cast(dict[str, Any], v)
+
+
+def _reject_extra_keys(
+    d: dict[str, Any], allowed: frozenset[str], where: str
+) -> None:
+    extras = set(d.keys()) - allowed
+    if extras:
+        raise NotationError(
+            f"{where} has unexpected keys {sorted(extras)!r}; "
+            f"allowed: {sorted(allowed)!r}"
+        )
+
+
+def _parse_int_coord_array(v: Any, where: str) -> Square4D:
+    if not isinstance(v, list) or len(v) != 4:
+        raise NotationError(
+            f"{where} must be a 4-element array of integers, got {v!r}"
+        )
+    for i, x in enumerate(v):
+        if isinstance(x, bool) or not isinstance(x, int):
+            raise NotationError(
+                f"{where}[{i}] must be an integer, got {type(x).__name__}"
+            )
+        if not 0 <= x < BOARD_SIZE:
+            raise NotationError(
+                f"{where}[{i}] = {x} out of range [0, {BOARD_SIZE})"
+            )
+    xs = cast(list[int], v)
+    return Square4D(xs[0], xs[1], xs[2], xs[3])
+
+
+def _parse_int_pair(v: Any, where: str) -> tuple[int, int]:
+    if not isinstance(v, list) or len(v) != 2:
+        raise NotationError(
+            f"{where} must be a 2-element array of integers, got {v!r}"
+        )
+    for i, x in enumerate(v):
+        if isinstance(x, bool) or not isinstance(x, int):
+            raise NotationError(
+                f"{where}[{i}] must be an integer, got {type(x).__name__}"
+            )
+        if not 0 <= x < BOARD_SIZE:
+            raise NotationError(
+                f"{where}[{i}] = {x} out of range [0, {BOARD_SIZE})"
+            )
+    xs = cast(list[int], v)
+    return (xs[0], xs[1])
+
+
+def _parse_enum(
+    v: Any, table: dict[str, Any], where: str, enum_name: str
+) -> Any:
+    if not isinstance(v, str):
+        raise NotationError(
+            f"{where} must be a string, got {type(v).__name__}"
+        )
+    if v not in table:
+        raise NotationError(
+            f"{where} must be one of {sorted(table)!r} ({enum_name} name), "
+            f"got {v!r}"
+        )
+    return table[v]
+
+
+def _parse_bool(v: Any, where: str) -> bool:
+    if not isinstance(v, bool):
+        raise NotationError(
+            f"{where} must be a boolean, got {type(v).__name__}"
+        )
+    return v
+
+
+# Move -----------------------------------------------------------------------
+
+
+def move_from_obj(obj: Any) -> Move4D:
+    """Build a :class:`Move4D` from a parsed JSON object (``dict``)."""
+    d = _ensure_object(obj, "move")
+    _reject_extra_keys(d, _MOVE_KEYS, "move")
+    if "from" not in d:
+        raise NotationError("move missing required key 'from'")
+    if "to" not in d:
+        raise NotationError("move missing required key 'to'")
+    from_sq = _parse_int_coord_array(d["from"], "move.from")
+    to_sq = _parse_int_coord_array(d["to"], "move.to")
+    promotion: PieceType | None = None
+    if "promotion" in d and d["promotion"] is not None:
+        pt = _parse_enum(
+            d["promotion"], _PIECE_TYPE_BY_NAME, "move.promotion", "PieceType"
+        )
+        if pt not in _PROMOTION_TYPES:
+            raise NotationError(
+                f"move.promotion must be one of "
+                f"{sorted(p.name for p in _PROMOTION_TYPES)!r}, got {pt.name!r}"
+            )
+        promotion = pt
+    is_castling = False
+    if "is_castling" in d:
+        is_castling = _parse_bool(d["is_castling"], "move.is_castling")
+    is_en_passant = False
+    if "is_en_passant" in d:
+        is_en_passant = _parse_bool(d["is_en_passant"], "move.is_en_passant")
+    return Move4D(
+        from_sq=from_sq,
+        to_sq=to_sq,
+        promotion=promotion,
+        is_castling=is_castling,
+        is_en_passant=is_en_passant,
+    )
+
+
+def move_to_obj(m: Move4D) -> dict[str, Any]:
+    """Serialize :class:`Move4D` to a JSON-compatible ``dict``."""
+    return {
+        "from": list(m.from_sq),
+        "to": list(m.to_sq),
+        "promotion": m.promotion.name if m.promotion is not None else None,
+        "is_castling": m.is_castling,
+        "is_en_passant": m.is_en_passant,
+    }
+
+
+def parse_json_move(s: str) -> Move4D:
+    """Parse a JSON move string into a :class:`Move4D`."""
+    try:
+        obj = json.loads(s)
+    except json.JSONDecodeError as exc:
+        raise NotationError(f"invalid JSON in move: {exc.msg}") from exc
+    return move_from_obj(obj)
+
+
+def render_json_move(m: Move4D) -> str:
+    """Render :class:`Move4D` as a compact single-line JSON string."""
+    return json.dumps(move_to_obj(m), separators=(",", ":"))
+
+
+# Castling-right records -----------------------------------------------------
+
+
+def _castling_right_from_obj(obj: Any, where: str) -> CastlingRight:
+    d = _ensure_object(obj, where)
+    _reject_extra_keys(d, _CASTLING_RIGHT_KEYS, where)
+    for k in _CASTLING_RIGHT_KEYS:
+        if k not in d:
+            raise NotationError(f"{where} missing required key {k!r}")
+    color = _parse_enum(d["color"], _COLOR_BY_NAME, f"{where}.color", "Color")
+    z, w = _parse_int_pair(d["slice"], f"{where}.slice")
+    side = _parse_enum(
+        d["side"], _CASTLE_SIDE_BY_NAME, f"{where}.side", "CastleSide"
+    )
+    return (color, z, w, side)
+
+
+def _castling_right_to_obj(r: CastlingRight) -> dict[str, Any]:
+    color, z, w, side = r
+    return {
+        "color": color.name,
+        "slice": [z, w],
+        "side": side.name,
+    }
+
+
+# Placement records ----------------------------------------------------------
+
+
+def _placement_from_obj(obj: Any, where: str) -> tuple[Square4D, Piece]:
+    d = _ensure_object(obj, where)
+    _reject_extra_keys(d, _PLACEMENT_KEYS, where)
+    for k in ("square", "color", "piece_type"):
+        if k not in d:
+            raise NotationError(f"{where} missing required key {k!r}")
+    sq = _parse_int_coord_array(d["square"], f"{where}.square")
+    color = _parse_enum(d["color"], _COLOR_BY_NAME, f"{where}.color", "Color")
+    piece_type = _parse_enum(
+        d["piece_type"], _PIECE_TYPE_BY_NAME, f"{where}.piece_type", "PieceType"
+    )
+    pawn_axis: PawnAxis | None = None
+    raw_axis = d.get("pawn_axis")
+    if raw_axis is not None:
+        pawn_axis = _parse_enum(
+            raw_axis, _PAWN_AXIS_BY_NAME, f"{where}.pawn_axis", "PawnAxis"
+        )
+    # Piece.__post_init__ enforces the pawn/axis correlation.
+    try:
+        piece = Piece(color=color, piece_type=piece_type, pawn_axis=pawn_axis)
+    except ValueError as exc:
+        raise NotationError(f"{where}: {exc}") from exc
+    return sq, piece
+
+
+def _placement_to_obj(sq: Square4D, piece: Piece) -> dict[str, Any]:
+    return {
+        "square": list(sq),
+        "color": piece.color.name,
+        "piece_type": piece.piece_type.name,
+        "pawn_axis": piece.pawn_axis.name if piece.pawn_axis is not None else None,
+    }
+
+
+# Position -------------------------------------------------------------------
+
+
+def _parse_optional_coord(v: Any, where: str) -> Square4D | None:
+    if v is None:
+        return None
+    return _parse_int_coord_array(v, where)
+
+
+def position_from_obj(obj: Any) -> GameState:
+    """Build a :class:`GameState` from a parsed JSON position object."""
+    d = _ensure_object(obj, "position")
+    _reject_extra_keys(d, _POSITION_KEYS, "position")
+    for k in ("placements", "side_to_move"):
+        if k not in d:
+            raise NotationError(f"position missing required key {k!r}")
+
+    placements_raw = d["placements"]
+    if not isinstance(placements_raw, list):
+        raise NotationError(
+            f"position.placements must be an array, got "
+            f"{type(placements_raw).__name__}"
+        )
+    board = Board4D()
+    for i, entry in enumerate(placements_raw):
+        sq, piece = _placement_from_obj(entry, f"position.placements[{i}]")
+        board.place(sq, piece)
+
+    side_to_move = _parse_enum(
+        d["side_to_move"], _COLOR_BY_NAME, "position.side_to_move", "Color"
+    )
+
+    rights_raw = d.get("castling_rights", [])
+    if not isinstance(rights_raw, list):
+        raise NotationError(
+            f"position.castling_rights must be an array, got "
+            f"{type(rights_raw).__name__}"
+        )
+    rights_set: set[CastlingRight] = set()
+    for i, entry in enumerate(rights_raw):
+        right = _castling_right_from_obj(
+            entry, f"position.castling_rights[{i}]"
+        )
+        if right in rights_set:
+            raise NotationError(
+                f"position.castling_rights[{i}] duplicates an earlier entry"
+            )
+        rights_set.add(right)
+
+    ep_target = _parse_optional_coord(d.get("ep_target"), "position.ep_target")
+    ep_victim = _parse_optional_coord(d.get("ep_victim"), "position.ep_victim")
+    ep_axis_raw = d.get("ep_axis")
+    ep_axis: PawnAxis | None = None
+    if ep_axis_raw is not None:
+        ep_axis = _parse_enum(
+            ep_axis_raw, _PAWN_AXIS_BY_NAME, "position.ep_axis", "PawnAxis"
+        )
+    # All three ep fields travel together.
+    ep_set = (ep_target is not None, ep_victim is not None, ep_axis is not None)
+    if any(ep_set) and not all(ep_set):
+        raise NotationError(
+            "position ep fields must be all null or all set; got "
+            f"target={ep_target!r}, victim={ep_victim!r}, axis={ep_axis!r}"
+        )
+
+    halfmove_raw = d.get("halfmove_clock", 0)
+    if isinstance(halfmove_raw, bool) or not isinstance(halfmove_raw, int):
+        raise NotationError(
+            f"position.halfmove_clock must be an integer, got "
+            f"{type(halfmove_raw).__name__}"
+        )
+    if halfmove_raw < 0:
+        raise NotationError(
+            f"position.halfmove_clock must be non-negative, got {halfmove_raw}"
+        )
+
+    return GameState(
+        board=board,
+        side_to_move=side_to_move,
+        castling_rights=frozenset(rights_set),
+        ep_target=ep_target,
+        ep_victim=ep_victim,
+        ep_axis=ep_axis,
+        halfmove_clock=halfmove_raw,
+    )
+
+
+def position_to_obj(gs: GameState) -> dict[str, Any]:
+    """Serialize a :class:`GameState` to a JSON-compatible ``dict``."""
+    sorted_squares = sorted(gs.board._squares.keys())
+    placements = [
+        _placement_to_obj(sq, gs.board._squares[sq]) for sq in sorted_squares
+    ]
+    ordered_rights = sorted(
+        gs.castling_rights,
+        key=lambda r: (int(r[0]), r[1], r[2], int(r[3])),
+    )
+    rights = [_castling_right_to_obj(r) for r in ordered_rights]
+    return {
+        "placements": placements,
+        "side_to_move": gs.side_to_move.name,
+        "castling_rights": rights,
+        "ep_target": list(gs.ep_target) if gs.ep_target is not None else None,
+        "ep_victim": list(gs.ep_victim) if gs.ep_victim is not None else None,
+        "ep_axis": gs.ep_axis.name if gs.ep_axis is not None else None,
+        "halfmove_clock": gs.halfmove_clock,
+    }
+
+
+def parse_json_position(s: str) -> GameState:
+    """Parse a JSON position string into a :class:`GameState`."""
+    try:
+        obj = json.loads(s)
+    except json.JSONDecodeError as exc:
+        raise NotationError(f"invalid JSON in position: {exc.msg}") from exc
+    return position_from_obj(obj)
+
+
+def render_json_position(gs: GameState) -> str:
+    """Render a :class:`GameState` as a compact single-line JSON string."""
+    return json.dumps(position_to_obj(gs), separators=(",", ":"))
+
+
+# Game -----------------------------------------------------------------------
+
+_GAME_KEYS: frozenset[str] = frozenset({"start", "moves"})
+
+
+def game_from_obj(obj: Any) -> tuple[GameState, list[Move4D]]:
+    """Build ``(start_state, move_list)`` from a parsed JSON game object.
+
+    ``start`` may be ``null`` (game starts from
+    :func:`chess4d.startpos.initial_position`) or a nested position
+    object. ``moves`` is an array of move objects. Moves are returned
+    unreplayed.
+    """
+    from chess4d.startpos import initial_position
+
+    d = _ensure_object(obj, "game")
+    _reject_extra_keys(d, _GAME_KEYS, "game")
+    if "moves" not in d:
+        raise NotationError("game missing required key 'moves'")
+
+    start_raw = d.get("start")
+    if start_raw is None:
+        start = initial_position()
+    else:
+        start = position_from_obj(start_raw)
+
+    moves_raw = d["moves"]
+    if not isinstance(moves_raw, list):
+        raise NotationError(
+            f"game.moves must be an array, got {type(moves_raw).__name__}"
+        )
+    moves: list[Move4D] = []
+    for i, entry in enumerate(moves_raw):
+        try:
+            moves.append(move_from_obj(entry))
+        except NotationError as exc:
+            raise NotationError(f"game.moves[{i}]: {exc}") from exc
+    return start, moves
+
+
+def game_to_obj(
+    start: GameState,
+    moves: list[Move4D],
+    *,
+    force_start: bool = False,
+) -> dict[str, Any]:
+    """Serialize a game to a JSON-compatible ``dict``.
+
+    If ``start`` is equivalent to :func:`chess4d.startpos.initial_position`
+    and ``force_start`` is ``False``, ``start`` is emitted as ``null``
+    (the parser defaults to ``initial_position()`` on ``null``).
+    Otherwise the full position object is emitted.
+    """
+    from chess4d.notation.compact import _game_starts_from_initial
+
+    if force_start or not _game_starts_from_initial(start):
+        start_obj: dict[str, Any] | None = position_to_obj(start)
+    else:
+        start_obj = None
+    return {
+        "start": start_obj,
+        "moves": [move_to_obj(m) for m in moves],
+    }
+
+
+def parse_json_game(s: str) -> tuple[GameState, list[Move4D]]:
+    """Parse a JSON game string into ``(start_state, move_list)``."""
+    try:
+        obj = json.loads(s)
+    except json.JSONDecodeError as exc:
+        raise NotationError(f"invalid JSON in game: {exc.msg}") from exc
+    return game_from_obj(obj)
+
+
+def render_json_game(
+    start: GameState,
+    moves: list[Move4D],
+    *,
+    force_start: bool = False,
+    indent: int | None = None,
+) -> str:
+    """Render a game as a JSON string.
+
+    ``indent`` mirrors :func:`json.dumps` — pass an integer to
+    pretty-print, or leave as ``None`` for a single-line compact form.
+    Game files on disk typically use ``indent=2``; in-memory interchange
+    uses the compact default.
+    """
+    obj = game_to_obj(start, moves, force_start=force_start)
+    if indent is None:
+        return json.dumps(obj, separators=(",", ":"))
+    return json.dumps(obj, indent=indent)

--- a/tests/test_notation_autodetect.py
+++ b/tests/test_notation_autodetect.py
@@ -1,0 +1,193 @@
+"""Phase 7E — top-level auto-detect notation API."""
+
+from __future__ import annotations
+
+import pytest
+
+from chess4d import Move4D, Square4D
+from chess4d.notation import (
+    NotationError,
+    parse_game,
+    parse_move,
+    parse_position,
+    render_game,
+    render_move,
+    render_position,
+)
+from chess4d.startpos import initial_position
+
+
+# parse_move -----------------------------------------------------------------
+
+
+def test_parse_move_detects_compact() -> None:
+    m = parse_move("a1c4-a3c4")
+    assert m == Move4D(Square4D(0, 0, 2, 3), Square4D(0, 2, 2, 3))
+
+
+def test_parse_move_detects_json() -> None:
+    s = '{"from":[0,0,2,3],"to":[0,2,2,3]}'
+    m = parse_move(s)
+    assert m == Move4D(Square4D(0, 0, 2, 3), Square4D(0, 2, 2, 3))
+
+
+def test_parse_move_detects_json_after_leading_whitespace() -> None:
+    s = '   \n\t {"from":[0,0,2,3],"to":[0,2,2,3]}'
+    m = parse_move(s)
+    assert m.from_sq == Square4D(0, 0, 2, 3)
+
+
+def test_parse_move_explicit_format_overrides_detection() -> None:
+    # A string starting with '{' but with format="compact" should be
+    # routed to the compact parser (which will reject it).
+    with pytest.raises(NotationError):
+        parse_move('{"from":[0,0,0,0]}', format="compact")
+
+
+def test_parse_move_invalid_format_raises() -> None:
+    with pytest.raises(NotationError) as exc_info:
+        parse_move("a1c4-a3c4", format="yaml")  # type: ignore[arg-type]
+    assert "must be 'compact' or 'json'" in str(exc_info.value)
+
+
+# render_move ----------------------------------------------------------------
+
+
+def test_render_move_defaults_to_compact() -> None:
+    m = Move4D(Square4D(0, 0, 2, 3), Square4D(0, 2, 2, 3))
+    assert render_move(m) == "a1c4-a3c4"
+
+
+def test_render_move_json() -> None:
+    m = Move4D(Square4D(0, 0, 2, 3), Square4D(0, 2, 2, 3))
+    s = render_move(m, format="json")
+    assert s.startswith("{")
+    assert '"from":[0,0,2,3]' in s
+
+
+def test_render_move_capture_flag_passes_through_compact() -> None:
+    m = Move4D(Square4D(0, 0, 2, 3), Square4D(0, 2, 2, 3))
+    assert render_move(m, is_capture=True) == "a1c4xa3c4"
+
+
+def test_render_move_capture_flag_ignored_for_json() -> None:
+    m = Move4D(Square4D(0, 0, 2, 3), Square4D(0, 2, 2, 3))
+    # is_capture has no effect on JSON output.
+    s1 = render_move(m, format="json", is_capture=False)
+    s2 = render_move(m, format="json", is_capture=True)
+    assert s1 == s2
+
+
+# parse_position / render_position -------------------------------------------
+
+
+def test_parse_position_detects_compact() -> None:
+    gs = parse_position("w - - 0")
+    assert gs.side_to_move.name == "WHITE"
+
+
+def test_parse_position_detects_json() -> None:
+    gs = parse_position('{"placements":[],"side_to_move":"WHITE"}')
+    assert gs.side_to_move.name == "WHITE"
+
+
+def test_render_position_round_trip_compact() -> None:
+    gs = initial_position()
+    s = render_position(gs)  # default compact
+    gs2 = parse_position(s)
+    assert gs2.board == gs.board
+
+
+def test_render_position_round_trip_json() -> None:
+    gs = initial_position()
+    s = render_position(gs, format="json")
+    assert s.startswith("{")
+    gs2 = parse_position(s)
+    assert gs2.board == gs.board
+
+
+# parse_game / render_game ---------------------------------------------------
+
+
+def test_parse_game_detects_compact() -> None:
+    start, moves = parse_game("a2c4-a4c4")
+    assert start.board == initial_position().board
+    assert len(moves) == 1
+
+
+def test_parse_game_detects_json() -> None:
+    s = (
+        '{"start":null,"moves":[{"from":[0,1,2,3],"to":[0,3,2,3],'
+        '"promotion":null,"is_castling":false,"is_en_passant":false}]}'
+    )
+    start, moves = parse_game(s)
+    assert len(moves) == 1
+    assert moves[0].from_sq == Square4D(0, 1, 2, 3)
+
+
+def test_render_game_round_trip_both_formats() -> None:
+    start = initial_position()
+    moves = [Move4D(Square4D(0, 1, 3, 3), Square4D(0, 3, 3, 3))]
+    for fmt in ("compact", "json"):
+        s = render_game(start, moves, format=fmt)  # type: ignore[arg-type]
+        start2, moves2 = parse_game(s)
+        assert moves2 == moves
+        assert start2.board == start.board
+
+
+def test_render_game_force_start_both_formats() -> None:
+    start = initial_position()
+    moves = [Move4D(Square4D(0, 1, 3, 3), Square4D(0, 3, 3, 3))]
+    compact_forced = render_game(start, moves, format="compact", force_start=True)
+    json_forced = render_game(start, moves, format="json", force_start=True)
+    # Compact: first line is position header.
+    assert compact_forced.splitlines()[0].startswith("w ")
+    # JSON: "start" is not null.
+    assert '"start":null' not in json_forced
+
+
+def test_parse_game_empty_string_is_compact() -> None:
+    # Empty string detection falls back to compact; compact treats it
+    # as an empty game (initial_position, no moves).
+    start, moves = parse_game("")
+    assert start.board == initial_position().board
+    assert moves == []
+
+
+def test_parse_move_whitespace_only_compact_raises() -> None:
+    # All-whitespace routes to compact, which rejects empty moves.
+    with pytest.raises(NotationError):
+        parse_move("   ")
+
+
+# Explicit format= on parse_* overrides detection ----------------------------
+
+
+def test_parse_position_explicit_compact_on_json_input_raises() -> None:
+    s = '{"placements":[],"side_to_move":"WHITE"}'
+    with pytest.raises(NotationError):
+        parse_position(s, format="compact")
+
+
+def test_parse_game_explicit_json_on_compact_input_raises() -> None:
+    with pytest.raises(NotationError):
+        parse_game("a2c4-a4c4", format="json")
+
+
+# Mixed-format in one session ------------------------------------------------
+
+
+def test_same_move_in_both_formats_parses_to_equal_move4d() -> None:
+    compact_m = parse_move("a1c4-a3c4")
+    json_m = parse_move('{"from":[0,0,2,3],"to":[0,2,2,3]}')
+    assert compact_m == json_m
+
+
+def test_same_position_in_both_formats_parses_to_equal_gamestate() -> None:
+    gs = initial_position()
+    compact_s = render_position(gs)
+    json_s = render_position(gs, format="json")
+    gs_from_compact = parse_position(compact_s)
+    gs_from_json = parse_position(json_s)
+    assert gs_from_compact.board == gs_from_json.board
+    assert gs_from_compact.side_to_move is gs_from_json.side_to_move

--- a/tests/test_notation_compact_move.py
+++ b/tests/test_notation_compact_move.py
@@ -1,0 +1,288 @@
+"""Phase 7A — compact move notation parse/render/round-trip."""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, strategies as st
+
+from chess4d import (
+    BOARD_SIZE,
+    CastleSide,
+    Color,
+    Move4D,
+    PieceType,
+    Square4D,
+)
+from chess4d.notation import (
+    NotationError,
+    parse_compact_move,
+    render_compact_move,
+)
+
+# Reusable strategies ---------------------------------------------------------
+
+_coord = st.integers(min_value=0, max_value=BOARD_SIZE - 1)
+_sq = st.builds(Square4D, _coord, _coord, _coord, _coord)
+_promo = st.sampled_from(
+    [PieceType.QUEEN, PieceType.ROOK, PieceType.BISHOP, PieceType.KNIGHT]
+)
+
+# Ordinary moves --------------------------------------------------------------
+
+
+def test_parse_ordinary_spec_example() -> None:
+    # Spec sample: a1c4-a2c4  (x=0, y=0, z=2, w=3) -> (x=0, y=1, z=2, w=3)
+    m = parse_compact_move("a1c4-a2c4")
+    assert m == Move4D(Square4D(0, 0, 2, 3), Square4D(0, 1, 2, 3))
+    assert m.promotion is None
+    assert not m.is_castling
+    assert not m.is_en_passant
+
+
+def test_parse_ordinary_corner_to_corner() -> None:
+    m = parse_compact_move("h8h8-a1a1")
+    assert m.from_sq == Square4D(7, 7, 7, 7)
+    assert m.to_sq == Square4D(0, 0, 0, 0)
+
+
+def test_render_ordinary_matches_spec_example() -> None:
+    m = Move4D(Square4D(0, 0, 2, 3), Square4D(0, 1, 2, 3))
+    assert render_compact_move(m) == "a1c4-a2c4"
+
+
+# Captures --------------------------------------------------------------------
+
+
+def test_parse_capture_spec_example() -> None:
+    m = parse_compact_move("a1c4xa3c4")
+    assert m == Move4D(Square4D(0, 0, 2, 3), Square4D(0, 2, 2, 3))
+
+
+def test_render_capture_requires_flag() -> None:
+    m = Move4D(Square4D(0, 0, 2, 3), Square4D(0, 2, 2, 3))
+    assert render_compact_move(m, is_capture=True) == "a1c4xa3c4"
+    # Default is non-capture regardless of actual board state.
+    assert render_compact_move(m) == "a1c4-a3c4"
+
+
+# Promotion -------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("ch", "pt"),
+    [
+        ("Q", PieceType.QUEEN),
+        ("R", PieceType.ROOK),
+        ("B", PieceType.BISHOP),
+        ("N", PieceType.KNIGHT),
+    ],
+)
+def test_parse_promotion_each_type(ch: str, pt: PieceType) -> None:
+    m = parse_compact_move(f"a7c4-a8c4={ch}")
+    assert m.promotion is pt
+    assert m.from_sq == Square4D(0, 6, 2, 3)
+    assert m.to_sq == Square4D(0, 7, 2, 3)
+
+
+def test_parse_capture_promotion_spec_example() -> None:
+    # Spec sample: a2c4xb3c4=Q
+    m = parse_compact_move("a2c4xb3c4=Q")
+    assert m.promotion is PieceType.QUEEN
+
+
+def test_render_promotion_non_capture() -> None:
+    m = Move4D(Square4D(0, 6, 2, 3), Square4D(0, 7, 2, 3), promotion=PieceType.QUEEN)
+    assert render_compact_move(m) == "a7c4-a8c4=Q"
+
+
+def test_render_promotion_with_capture_flag() -> None:
+    m = Move4D(Square4D(0, 6, 2, 3), Square4D(1, 7, 2, 3), promotion=PieceType.KNIGHT)
+    assert render_compact_move(m, is_capture=True) == "a7c4xb8c4=N"
+
+
+# En passant ------------------------------------------------------------------
+
+
+def test_parse_ep_spec_example() -> None:
+    # Spec sample: a2c4xa3c4ep
+    m = parse_compact_move("a2c4xa3c4ep")
+    assert m.is_en_passant
+    assert m.from_sq == Square4D(0, 1, 2, 3)
+    assert m.to_sq == Square4D(0, 2, 2, 3)
+
+
+def test_render_ep_uses_x_and_suffix() -> None:
+    m = Move4D(Square4D(0, 1, 2, 3), Square4D(0, 2, 2, 3), is_en_passant=True)
+    # Renderer forces 'x' for ep regardless of the flag.
+    assert render_compact_move(m) == "a2c4xa3c4ep"
+    assert render_compact_move(m, is_capture=True) == "a2c4xa3c4ep"
+
+
+# Castling --------------------------------------------------------------------
+
+
+def test_parse_castle_white_kingside() -> None:
+    # Spec: O-O@c4 is kingside on slice z=2, w=3.
+    m = parse_compact_move("O-O@c4")
+    assert m == Move4D(
+        Square4D(4, 0, 2, 3),
+        Square4D(6, 0, 2, 3),
+        is_castling=True,
+    )
+
+
+def test_parse_castle_white_queenside() -> None:
+    m = parse_compact_move("O-O-O@c4")
+    assert m == Move4D(
+        Square4D(4, 0, 2, 3),
+        Square4D(2, 0, 2, 3),
+        is_castling=True,
+    )
+
+
+def test_parse_castle_black_kingside() -> None:
+    m = parse_compact_move("o-o@c4")
+    assert m == Move4D(
+        Square4D(4, 7, 2, 3),
+        Square4D(6, 7, 2, 3),
+        is_castling=True,
+    )
+
+
+def test_parse_castle_black_queenside() -> None:
+    m = parse_compact_move("o-o-o@c4")
+    assert m == Move4D(
+        Square4D(4, 7, 2, 3),
+        Square4D(2, 7, 2, 3),
+        is_castling=True,
+    )
+
+
+def test_render_castle_white_kingside() -> None:
+    m = Move4D(Square4D(4, 0, 2, 3), Square4D(6, 0, 2, 3), is_castling=True)
+    assert render_compact_move(m) == "O-O@c4"
+
+
+def test_render_castle_white_queenside() -> None:
+    m = Move4D(Square4D(4, 0, 2, 3), Square4D(2, 0, 2, 3), is_castling=True)
+    assert render_compact_move(m) == "O-O-O@c4"
+
+
+def test_render_castle_black_kingside() -> None:
+    m = Move4D(Square4D(4, 7, 2, 3), Square4D(6, 7, 2, 3), is_castling=True)
+    assert render_compact_move(m) == "o-o@c4"
+
+
+def test_render_castle_black_queenside() -> None:
+    m = Move4D(Square4D(4, 7, 2, 3), Square4D(2, 7, 2, 3), is_castling=True)
+    assert render_compact_move(m) == "o-o-o@c4"
+
+
+# Invalid inputs --------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("bad", "fragment"),
+    [
+        ("", "empty move"),
+        ("a1c", "too short"),
+        ("z1c4-a2c4", "letter a-h"),
+        ("a9c4-a2c4", "digit 1-8"),
+        ("1aa1-a2c4", "letter a-h"),
+        ("a1c4!a2c4", "'-' or 'x'"),
+        ("a1c4-a2c4=q", "Q/R/B/N"),
+        ("a1c4-a2c4=X", "Q/R/B/N"),
+        ("a1c4-a2c4=", "trailing"),
+        ("a1c4-a2c4ep", "requires 'x'"),
+        ("a1c4-a2c4junk", "trailing"),
+        ("O-O", "@<slice>"),
+        ("O-O@c", "2 characters"),
+        ("O-Ox@c4", "invalid castling token"),
+        ("O-O-O-O@c4", "invalid castling token"),
+        ("O-O@i4", "letter a-h"),
+        ("O-O@c9", "digit 1-8"),
+    ],
+)
+def test_parse_invalid_raises(bad: str, fragment: str) -> None:
+    with pytest.raises(NotationError) as exc_info:
+        parse_compact_move(bad)
+    assert fragment in str(exc_info.value), (
+        f"expected fragment {fragment!r} in error, got {exc_info.value!s}"
+    )
+
+
+def test_notation_error_is_valueerror() -> None:
+    with pytest.raises(ValueError):
+        parse_compact_move("")
+
+
+# Render rejects malformed castling -------------------------------------------
+
+
+def test_render_castle_rejects_non_back_rank() -> None:
+    m = Move4D(Square4D(4, 3, 2, 3), Square4D(6, 3, 2, 3), is_castling=True)
+    with pytest.raises(ValueError):
+        render_compact_move(m)
+
+
+def test_render_castle_rejects_bad_king_x() -> None:
+    m = Move4D(Square4D(3, 0, 2, 3), Square4D(6, 0, 2, 3), is_castling=True)
+    with pytest.raises(ValueError):
+        render_compact_move(m)
+
+
+def test_render_castle_rejects_slice_change() -> None:
+    m = Move4D(Square4D(4, 0, 2, 3), Square4D(6, 0, 3, 3), is_castling=True)
+    with pytest.raises(ValueError):
+        render_compact_move(m)
+
+
+# Round-trip (Hypothesis) -----------------------------------------------------
+
+
+@given(from_sq=_sq, to_sq=_sq)
+def test_roundtrip_ordinary(from_sq: Square4D, to_sq: Square4D) -> None:
+    m = Move4D(from_sq, to_sq)
+    assert parse_compact_move(render_compact_move(m)) == m
+
+
+@given(from_sq=_sq, to_sq=_sq)
+def test_roundtrip_capture(from_sq: Square4D, to_sq: Square4D) -> None:
+    m = Move4D(from_sq, to_sq)
+    s = render_compact_move(m, is_capture=True)
+    # Capture marker is informational; parsed Move4D compares equal.
+    assert parse_compact_move(s) == m
+
+
+@given(from_sq=_sq, to_sq=_sq, promo=_promo)
+def test_roundtrip_promotion(
+    from_sq: Square4D, to_sq: Square4D, promo: PieceType
+) -> None:
+    m = Move4D(from_sq, to_sq, promotion=promo)
+    assert parse_compact_move(render_compact_move(m)) == m
+    assert parse_compact_move(render_compact_move(m, is_capture=True)) == m
+
+
+@given(from_sq=_sq, to_sq=_sq)
+def test_roundtrip_en_passant(from_sq: Square4D, to_sq: Square4D) -> None:
+    m = Move4D(from_sq, to_sq, is_en_passant=True)
+    assert parse_compact_move(render_compact_move(m)) == m
+
+
+@given(
+    color=st.sampled_from([Color.WHITE, Color.BLACK]),
+    side=st.sampled_from([CastleSide.KINGSIDE, CastleSide.QUEENSIDE]),
+    z=_coord,
+    w=_coord,
+)
+def test_roundtrip_castle(
+    color: Color, side: CastleSide, z: int, w: int
+) -> None:
+    back_y = 0 if color is Color.WHITE else BOARD_SIZE - 1
+    to_x = 6 if side is CastleSide.KINGSIDE else 2
+    m = Move4D(
+        Square4D(4, back_y, z, w),
+        Square4D(to_x, back_y, z, w),
+        is_castling=True,
+    )
+    assert parse_compact_move(render_compact_move(m)) == m

--- a/tests/test_notation_compact_position.py
+++ b/tests/test_notation_compact_position.py
@@ -1,0 +1,285 @@
+"""Phase 7B — compact position notation parse/render/round-trip."""
+
+from __future__ import annotations
+
+import pytest
+
+from chess4d import (
+    Board4D,
+    CastleSide,
+    Color,
+    GameState,
+    Move4D,
+    PawnAxis,
+    Piece,
+    PieceType,
+    Square4D,
+)
+from chess4d.notation import (
+    NotationError,
+    parse_compact_position,
+    render_compact_position,
+)
+from chess4d.startpos import initial_position
+
+# Round-trip: the real starting position ------------------------------------
+
+
+def test_round_trip_initial_position() -> None:
+    gs = initial_position()
+    s = render_compact_position(gs)
+    gs2 = parse_compact_position(s)
+    assert gs2.board == gs.board
+    assert gs2.side_to_move is gs.side_to_move
+    assert gs2.castling_rights == gs.castling_rights
+    assert gs2.ep_target == gs.ep_target
+    assert gs2.ep_victim == gs.ep_victim
+    assert gs2.ep_axis == gs.ep_axis
+    assert gs2.halfmove_clock == gs.halfmove_clock
+
+
+def test_initial_position_header_encodes_all_112_rights() -> None:
+    gs = initial_position()
+    header_line = render_compact_position(gs).split("\n", 1)[0]
+    rights_tok = header_line.split(" ")[1]
+    assert rights_tok.count(",") == 111  # 112 tokens => 111 commas
+
+
+def test_initial_position_omits_12_empty_slices() -> None:
+    gs = initial_position()
+    lines = render_compact_position(gs).split("\n")
+    # 1 header + 52 populated slice lines (64 total minus 12 empty).
+    assert len(lines) == 1 + 52
+
+
+# Empty / sparse boards ------------------------------------------------------
+
+
+def test_empty_board_is_just_header() -> None:
+    gs = GameState(board=Board4D(), side_to_move=Color.WHITE)
+    s = render_compact_position(gs)
+    assert s == "w - - 0"
+    gs2 = parse_compact_position(s)
+    assert gs2.board == gs.board
+    assert gs2.side_to_move is Color.WHITE
+    assert gs2.castling_rights == frozenset()
+    assert gs2.ep_target is None
+    assert gs2.halfmove_clock == 0
+
+
+def test_empty_board_header_only_eof_round_trips() -> None:
+    s = "w - - 0"
+    gs = parse_compact_position(s)
+    assert gs.board == Board4D()
+    assert render_compact_position(gs) == s
+
+
+def test_single_piece_slice() -> None:
+    board = Board4D()
+    board.place(Square4D(3, 2, 1, 4), Piece(Color.BLACK, PieceType.KNIGHT))
+    gs = GameState(board=board, side_to_move=Color.BLACK, halfmove_clock=7)
+    s = render_compact_position(gs)
+    gs2 = parse_compact_position(s)
+    assert gs2.board == board
+    assert gs2.side_to_move is Color.BLACK
+    assert gs2.halfmove_clock == 7
+
+
+# Castling rights -----------------------------------------------------------
+
+
+def test_round_trip_partial_castling_rights() -> None:
+    board = Board4D()
+    gs = GameState(
+        board=board,
+        side_to_move=Color.WHITE,
+        castling_rights=frozenset(
+            [
+                (Color.WHITE, 3, 3, CastleSide.KINGSIDE),
+                (Color.BLACK, 2, 5, CastleSide.QUEENSIDE),
+            ]
+        ),
+    )
+    s = render_compact_position(gs)
+    assert "Wd4K" in s
+    assert "Bc6Q" in s
+    gs2 = parse_compact_position(s)
+    assert gs2.castling_rights == gs.castling_rights
+
+
+def test_castling_rights_are_sorted_canonically() -> None:
+    board = Board4D()
+    rights_unsorted = frozenset(
+        [
+            (Color.BLACK, 3, 3, CastleSide.QUEENSIDE),
+            (Color.WHITE, 0, 0, CastleSide.QUEENSIDE),
+            (Color.WHITE, 0, 0, CastleSide.KINGSIDE),
+        ]
+    )
+    gs = GameState(
+        board=board, side_to_move=Color.WHITE, castling_rights=rights_unsorted
+    )
+    header = render_compact_position(gs).split("\n", 1)[0]
+    rights_tok = header.split(" ")[1]
+    assert rights_tok == "Wa1K,Wa1Q,Bd4Q"
+
+
+# En passant ----------------------------------------------------------------
+
+
+def test_round_trip_y_axis_ep_state() -> None:
+    # White pushes a Y-pawn two squares from y=1 to y=3 on slice (2, 3).
+    gs = initial_position()
+    from_sq = Square4D(0, 1, 2, 3)
+    to_sq = Square4D(0, 3, 2, 3)
+    gs.push(Move4D(from_sq, to_sq))
+    assert gs.ep_target == Square4D(0, 2, 2, 3)
+    s = render_compact_position(gs)
+    gs2 = parse_compact_position(s)
+    assert gs2.ep_target == gs.ep_target
+    assert gs2.ep_victim == gs.ep_victim
+    assert gs2.ep_axis is PawnAxis.Y
+
+
+def test_round_trip_w_axis_ep_state_manual() -> None:
+    board = Board4D()
+    # A single W-oriented black pawn in the middle of an otherwise empty board,
+    # reachable ep-state: it just moved from w=6 to w=4, so ep_target at w=5.
+    board.place(Square4D(4, 4, 3, 4), Piece(Color.BLACK, PieceType.PAWN, PawnAxis.W))
+    gs = GameState(
+        board=board,
+        side_to_move=Color.WHITE,
+        ep_target=Square4D(4, 4, 3, 5),
+        ep_victim=Square4D(4, 4, 3, 4),
+        ep_axis=PawnAxis.W,
+    )
+    s = render_compact_position(gs)
+    gs2 = parse_compact_position(s)
+    assert gs2.ep_target == gs.ep_target
+    assert gs2.ep_victim == gs.ep_victim
+    assert gs2.ep_axis is PawnAxis.W
+
+
+def test_parse_ep_target_missing_victim_raises() -> None:
+    # Header claims an ep_target but no adjacent pawn sits on the board.
+    s = "w - a3c4 0"
+    with pytest.raises(NotationError) as exc_info:
+        parse_compact_position(s)
+    assert "no adjacent enemy pawn" in str(exc_info.value)
+
+
+# Handwritten / whitespace tolerance ----------------------------------------
+
+
+def test_parse_tolerates_blank_lines_between_slices() -> None:
+    raw = "\n".join(
+        [
+            "w - - 0",
+            "",
+            "a1: RNBQKBNR/YYYYYYYY/......../......../......../......../yyyyyyyy/rnbqkbnr",
+            "",
+            "",
+            "a2: RNBQKBNR/YYYYYYYY/......../......../......../......../yyyyyyyy/rnbqkbnr",
+        ]
+    )
+    gs = parse_compact_position(raw)
+    assert gs.side_to_move is Color.WHITE
+    # Two populated slices.
+    assert sum(1 for _ in gs.board.pieces_of(Color.WHITE)) == 32
+    assert sum(1 for _ in gs.board.pieces_of(Color.BLACK)) == 32
+
+
+def test_parse_tolerates_trailing_whitespace() -> None:
+    raw = "w - - 0   \na1: RNBQKBNR/YYYYYYYY/......../......../......../......../yyyyyyyy/rnbqkbnr  \n"
+    gs = parse_compact_position(raw)
+    assert sum(1 for _ in gs.board.pieces_of(Color.WHITE)) == 16
+
+
+def test_parse_accepts_empty_slice_marker() -> None:
+    raw = "w - - 0\na1: empty\n"
+    gs = parse_compact_position(raw)
+    assert gs.board == Board4D()
+
+
+def test_parse_accepts_uppercase_side_char() -> None:
+    gs = parse_compact_position("W - - 0")
+    assert gs.side_to_move is Color.WHITE
+    gs = parse_compact_position("B - - 0")
+    assert gs.side_to_move is Color.BLACK
+
+
+# Invalid inputs ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("bad", "fragment"),
+    [
+        ("", "no header"),
+        ("   \n\n", "no header"),
+        ("w -", "4 space-separated"),
+        ("z - - 0", "'w' or 'b'"),
+        ("w - - xyz", "decimal integer"),
+        ("w - - -1", "non-negative"),
+        ("w Wa1X - 0", "'K' or 'Q'"),
+        ("w Xa1K - 0", "'W' or 'B'"),
+        ("w Wa1 - 0", "4 characters"),
+        ("w Wa1K,Wa1K - 0", "duplicate"),
+        ("w - - 0\nxxx", "missing ':'"),
+        ("w - - 0\na1a: RNBQKBNR/YYYYYYYY/......../......../......../......../yyyyyyyy/rnbqkbnr", "slice key must be 2"),
+        ("w - - 0\na1: RNBQKBNR/YYYYYYYY", "8 ranks"),
+        ("w - - 0\na1: RNBQKBNR/YYYYYYYY/......../......../......../......../yyyyyyyy/rnbqkbn", "8 characters"),
+        ("w - - 0\na1: RNBQKBNR/YYYYYYYY/......../......../......../......../yyyyyyyy/ZZZZZZZZ", "unknown piece"),
+        ("w - - 0\na1: empty\na1: empty", "more than once"),
+    ],
+)
+def test_parse_invalid_raises(bad: str, fragment: str) -> None:
+    with pytest.raises(NotationError) as exc_info:
+        parse_compact_position(bad)
+    assert fragment in str(exc_info.value), (
+        f"expected fragment {fragment!r}, got {exc_info.value!s}"
+    )
+
+
+# Piece letters round-trip --------------------------------------------------
+
+
+def test_all_piece_types_round_trip() -> None:
+    board = Board4D()
+    placements = [
+        (Square4D(0, 0, 0, 0), Piece(Color.WHITE, PieceType.ROOK)),
+        (Square4D(1, 0, 0, 0), Piece(Color.WHITE, PieceType.KNIGHT)),
+        (Square4D(2, 0, 0, 0), Piece(Color.WHITE, PieceType.BISHOP)),
+        (Square4D(3, 0, 0, 0), Piece(Color.WHITE, PieceType.QUEEN)),
+        (Square4D(4, 0, 0, 0), Piece(Color.WHITE, PieceType.KING)),
+        (Square4D(5, 0, 0, 0), Piece(Color.WHITE, PieceType.PAWN, PawnAxis.Y)),
+        (Square4D(6, 0, 0, 0), Piece(Color.WHITE, PieceType.PAWN, PawnAxis.W)),
+        (Square4D(0, 7, 0, 0), Piece(Color.BLACK, PieceType.ROOK)),
+        (Square4D(1, 7, 0, 0), Piece(Color.BLACK, PieceType.KNIGHT)),
+        (Square4D(2, 7, 0, 0), Piece(Color.BLACK, PieceType.BISHOP)),
+        (Square4D(3, 7, 0, 0), Piece(Color.BLACK, PieceType.QUEEN)),
+        (Square4D(4, 7, 0, 0), Piece(Color.BLACK, PieceType.KING)),
+        (Square4D(5, 7, 0, 0), Piece(Color.BLACK, PieceType.PAWN, PawnAxis.Y)),
+        (Square4D(6, 7, 0, 0), Piece(Color.BLACK, PieceType.PAWN, PawnAxis.W)),
+    ]
+    for sq, p in placements:
+        board.place(sq, p)
+    gs = GameState(board=board, side_to_move=Color.WHITE)
+    gs2 = parse_compact_position(render_compact_position(gs))
+    assert gs2.board == board
+
+
+# Replay of a constructed mid-game position ---------------------------------
+
+
+def test_round_trip_after_a_legal_move() -> None:
+    gs = initial_position()
+    # A white Y-pawn advance from slice (3, 3) — a central slice.
+    gs.push(Move4D(Square4D(0, 1, 3, 3), Square4D(0, 3, 3, 3)))
+    s = render_compact_position(gs)
+    gs2 = parse_compact_position(s)
+    assert gs2.board == gs.board
+    assert gs2.side_to_move is Color.BLACK
+    assert gs2.castling_rights == gs.castling_rights
+    assert gs2.ep_target == gs.ep_target
+    assert gs2.ep_axis is PawnAxis.Y
+    assert gs2.halfmove_clock == gs.halfmove_clock

--- a/tests/test_notation_game.py
+++ b/tests/test_notation_game.py
@@ -1,0 +1,449 @@
+"""Phase 7D — game format (compact + JSON) and file I/O."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from chess4d import (
+    Board4D,
+    Color,
+    GameState,
+    Move4D,
+    PawnAxis,
+    Piece,
+    PieceType,
+    Square4D,
+)
+from chess4d.notation import (
+    NotationError,
+    parse_compact_game,
+    parse_json_game,
+    read_game_file,
+    read_position_file,
+    render_compact_game,
+    render_json_game,
+    write_game_file,
+    write_position_file,
+)
+from chess4d.startpos import initial_position
+
+
+# Fixtures -------------------------------------------------------------------
+
+
+def _advance(start: GameState, moves: list[Move4D]) -> GameState:
+    state = deepcopy(start)
+    for m in moves:
+        state.push(m)
+    return state
+
+
+def _pawn_push(from_sq: Square4D, to_sq: Square4D) -> Move4D:
+    return Move4D(from_sq, to_sq)
+
+
+def _two_pawn_game() -> tuple[GameState, list[Move4D]]:
+    """A 2-ply fixture: white then black Y-pawn double pushes."""
+    start = initial_position()
+    moves = [
+        _pawn_push(Square4D(0, 1, 3, 3), Square4D(0, 3, 3, 3)),
+        _pawn_push(Square4D(0, 6, 3, 3), Square4D(0, 4, 3, 3)),
+    ]
+    return start, moves
+
+
+def _longer_game() -> tuple[GameState, list[Move4D]]:
+    """A 10-ply alternating pawn-push game across slice (3, 3)."""
+    start = initial_position()
+    moves: list[Move4D] = []
+    # White pushes pawns from (x, 1, 3, 3) to (x, 2, 3, 3), alternating
+    # with black pushes from (x, 6, 3, 3) to (x, 5, 3, 3).
+    for x in range(5):
+        moves.append(_pawn_push(Square4D(x, 1, 3, 3), Square4D(x, 2, 3, 3)))
+        moves.append(_pawn_push(Square4D(x, 6, 3, 3), Square4D(x, 5, 3, 3)))
+    return start, moves
+
+
+# ---------------------------------------------------------------------------
+# Compact game format
+# ---------------------------------------------------------------------------
+
+
+def test_compact_game_initial_start_round_trip() -> None:
+    start, moves = _two_pawn_game()
+    s = render_compact_game(start, moves)
+    start2, moves2 = parse_compact_game(s)
+    assert start2.board == start.board
+    assert start2.side_to_move is start.side_to_move
+    assert moves2 == moves
+
+
+def test_compact_game_omits_start_when_equal_to_initial() -> None:
+    start, moves = _two_pawn_game()
+    s = render_compact_game(start, moves)
+    # The emitted text should NOT contain a position header like "w - ... 0".
+    assert not any(
+        line.strip().startswith(("w ", "b "))
+        and len(line.strip().split()) == 4
+        for line in s.splitlines()
+    )
+
+
+def test_compact_game_force_start_includes_position() -> None:
+    start, moves = _two_pawn_game()
+    s = render_compact_game(start, moves, force_start=True)
+    # First non-empty line should be a position header.
+    first = next(line for line in s.splitlines() if line.strip())
+    parts = first.strip().split()
+    assert len(parts) == 4 and parts[0] in ("w", "b")
+
+
+def test_compact_game_custom_start_round_trip() -> None:
+    board = Board4D()
+    board.place(Square4D(4, 0, 0, 0), Piece(Color.WHITE, PieceType.KING))
+    board.place(Square4D(4, 7, 0, 0), Piece(Color.BLACK, PieceType.KING))
+    start = GameState(board=board, side_to_move=Color.WHITE)
+    moves = [Move4D(Square4D(4, 0, 0, 0), Square4D(4, 1, 0, 0))]
+    s = render_compact_game(start, moves)
+    start2, moves2 = parse_compact_game(s)
+    assert start2.board == start.board
+    assert start2.side_to_move is Color.WHITE
+    assert moves2 == moves
+
+
+def test_compact_game_empty_string_yields_initial_with_no_moves() -> None:
+    start, moves = parse_compact_game("")
+    assert start.board == initial_position().board
+    assert moves == []
+
+
+def test_compact_game_comments_and_blanks_are_ignored() -> None:
+    raw = "\n".join(
+        [
+            "# a comment line",
+            "# another",
+            "",
+            "a2c4-a4c4",
+            "  ",
+            "# trailing comment",
+            "a7c4-a5c4",
+        ]
+    )
+    start, moves = parse_compact_game(raw)
+    assert start.board == initial_position().board
+    assert len(moves) == 2
+    assert moves[0].from_sq == Square4D(0, 1, 2, 3)
+
+
+def test_compact_game_capture_marker_replays_correctly() -> None:
+    # Build a game where move 1 captures.
+    board = Board4D()
+    board.place(Square4D(0, 0, 0, 0), Piece(Color.WHITE, PieceType.KING))
+    board.place(Square4D(7, 7, 0, 0), Piece(Color.BLACK, PieceType.KING))
+    board.place(Square4D(3, 3, 0, 0), Piece(Color.WHITE, PieceType.ROOK))
+    board.place(Square4D(3, 5, 0, 0), Piece(Color.BLACK, PieceType.PAWN, PawnAxis.Y))
+    start = GameState(board=board, side_to_move=Color.WHITE)
+    moves = [Move4D(Square4D(3, 3, 0, 0), Square4D(3, 5, 0, 0))]
+    s = render_compact_game(start, moves)
+    # The capture line should use 'x' as the separator.
+    assert "d4a1xd6a1" in s
+    start2, moves2 = parse_compact_game(s)
+    assert moves2 == moves
+
+
+def test_compact_game_trailing_newline_in_output() -> None:
+    start, moves = _two_pawn_game()
+    s = render_compact_game(start, moves)
+    assert s.endswith("\n")
+
+
+def test_compact_game_bad_move_reports_index() -> None:
+    raw = "a2c4-a4c4\nxxxxxxxxx"
+    with pytest.raises(NotationError) as exc_info:
+        parse_compact_game(raw)
+    assert "move #2" in str(exc_info.value)
+
+
+def test_compact_game_longer_replay_matches_end_state() -> None:
+    start, moves = _longer_game()
+    s = render_compact_game(start, moves)
+    start2, moves2 = parse_compact_game(s)
+    assert moves2 == moves
+    final = _advance(start, moves)
+    final2 = _advance(start2, moves2)
+    assert final.board == final2.board
+    assert final.side_to_move is final2.side_to_move
+    assert final.halfmove_clock == final2.halfmove_clock
+
+
+# ---------------------------------------------------------------------------
+# JSON game format
+# ---------------------------------------------------------------------------
+
+
+def test_json_game_initial_start_round_trip() -> None:
+    start, moves = _two_pawn_game()
+    s = render_json_game(start, moves)
+    obj = json.loads(s)
+    assert obj["start"] is None
+    assert len(obj["moves"]) == 2
+    start2, moves2 = parse_json_game(s)
+    assert start2.board == start.board
+    assert moves2 == moves
+
+
+def test_json_game_custom_start_round_trip() -> None:
+    board = Board4D()
+    board.place(Square4D(4, 0, 0, 0), Piece(Color.WHITE, PieceType.KING))
+    board.place(Square4D(4, 7, 0, 0), Piece(Color.BLACK, PieceType.KING))
+    start = GameState(board=board, side_to_move=Color.WHITE)
+    moves = [Move4D(Square4D(4, 0, 0, 0), Square4D(4, 1, 0, 0))]
+    s = render_json_game(start, moves)
+    obj = json.loads(s)
+    assert obj["start"] is not None
+    start2, moves2 = parse_json_game(s)
+    assert start2.board == start.board
+    assert moves2 == moves
+
+
+def test_json_game_force_start_emits_initial_position() -> None:
+    start, moves = _two_pawn_game()
+    s = render_json_game(start, moves, force_start=True)
+    obj = json.loads(s)
+    assert obj["start"] is not None
+    assert isinstance(obj["start"]["placements"], list)
+
+
+def test_json_game_indent_produces_multiline_output() -> None:
+    start, moves = _two_pawn_game()
+    one_line = render_json_game(start, moves)
+    pretty = render_json_game(start, moves, indent=2)
+    assert "\n" not in one_line
+    assert "\n" in pretty
+
+
+def test_json_game_null_start_yields_initial_position() -> None:
+    s = '{"start":null,"moves":[]}'
+    start, moves = parse_json_game(s)
+    assert start.board == initial_position().board
+    assert moves == []
+
+
+def test_json_game_empty_moves_array() -> None:
+    s = '{"start":null,"moves":[]}'
+    _, moves = parse_json_game(s)
+    assert moves == []
+
+
+def test_json_game_roundtrip_longer_game() -> None:
+    start, moves = _longer_game()
+    s = render_json_game(start, moves)
+    start2, moves2 = parse_json_game(s)
+    assert moves2 == moves
+    final = _advance(start, moves)
+    final2 = _advance(start2, moves2)
+    assert final.board == final2.board
+
+
+@pytest.mark.parametrize(
+    ("bad", "fragment"),
+    [
+        ("[]", "must be a JSON object"),
+        ('"nope"', "must be a JSON object"),
+        ('{"moves":[], "extra":1}', "unexpected keys"),
+        ('{"start":null}', "missing required key 'moves'"),
+        ('{"start":null,"moves":"not-an-array"}', "must be an array"),
+        ('{"start":null,"moves":[{"from":[0,0,0,0]}]}', "missing required key 'to'"),
+        ("{not-json", "invalid JSON"),
+    ],
+)
+def test_json_game_invalid_raises(bad: str, fragment: str) -> None:
+    with pytest.raises(NotationError) as exc_info:
+        parse_json_game(bad)
+    assert fragment in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# File I/O
+# ---------------------------------------------------------------------------
+
+
+def test_write_and_read_game_file_compact(tmp_path: Path) -> None:
+    start, moves = _two_pawn_game()
+    p = tmp_path / "game.c4d"
+    write_game_file(p, start, moves)
+    assert p.exists()
+    start2, moves2 = read_game_file(p)
+    assert moves2 == moves
+    assert start2.board == start.board
+
+
+def test_write_and_read_game_file_json(tmp_path: Path) -> None:
+    start, moves = _two_pawn_game()
+    p = tmp_path / "game.json"
+    write_game_file(p, start, moves)
+    # File should be pretty-printed (contain newlines).
+    text = p.read_text(encoding="utf-8")
+    assert "\n" in text
+    start2, moves2 = read_game_file(p)
+    assert moves2 == moves
+    assert start2.board == start.board
+
+
+def test_write_and_read_position_file_compact(tmp_path: Path) -> None:
+    gs = initial_position()
+    p = tmp_path / "pos.c4dpos"
+    write_position_file(p, gs)
+    gs2 = read_position_file(p)
+    assert gs2.board == gs.board
+
+
+def test_write_and_read_position_file_json(tmp_path: Path) -> None:
+    gs = initial_position()
+    p = tmp_path / "pos.json"
+    write_position_file(p, gs)
+    gs2 = read_position_file(p)
+    assert gs2.board == gs.board
+
+
+def test_file_format_override_ignores_extension(tmp_path: Path) -> None:
+    start, moves = _two_pawn_game()
+    p = tmp_path / "game.json"  # json extension but we force compact
+    write_game_file(p, start, moves, format="compact")
+    # The content is compact, even though the extension is .json.
+    text = p.read_text(encoding="utf-8")
+    assert not text.lstrip().startswith("{")
+    start2, moves2 = read_game_file(p, format="compact")
+    assert moves2 == moves
+
+
+def test_file_unknown_extension_raises(tmp_path: Path) -> None:
+    p = tmp_path / "game.txt"
+    with pytest.raises(NotationError) as exc_info:
+        read_game_file(p)
+    assert "cannot infer notation format" in str(exc_info.value)
+
+
+def test_file_unknown_extension_write_raises(tmp_path: Path) -> None:
+    start, moves = _two_pawn_game()
+    p = tmp_path / "game.txt"
+    with pytest.raises(NotationError):
+        write_game_file(p, start, moves)
+
+
+def test_file_explicit_format_validates(tmp_path: Path) -> None:
+    start, moves = _two_pawn_game()
+    p = tmp_path / "game.c4d"
+    with pytest.raises(NotationError) as exc_info:
+        write_game_file(p, start, moves, format="bogus")  # type: ignore[arg-type]
+    assert "must be 'compact' or 'json'" in str(exc_info.value)
+
+
+def test_file_custom_start_replays_identically(tmp_path: Path) -> None:
+    board = Board4D()
+    board.place(Square4D(4, 0, 0, 0), Piece(Color.WHITE, PieceType.KING))
+    board.place(Square4D(4, 7, 0, 0), Piece(Color.BLACK, PieceType.KING))
+    board.place(
+        Square4D(2, 1, 0, 0), Piece(Color.WHITE, PieceType.PAWN, PawnAxis.Y)
+    )
+    start = GameState(
+        board=board,
+        side_to_move=Color.WHITE,
+        castling_rights=frozenset(),
+    )
+    moves = [Move4D(Square4D(2, 1, 0, 0), Square4D(2, 3, 0, 0))]
+
+    for ext in (".c4d", ".json"):
+        p = tmp_path / f"game{ext}"
+        write_game_file(p, start, moves)
+        start2, moves2 = read_game_file(p)
+        assert moves2 == moves
+        assert start2.board == start.board
+
+        replayed = _advance(start, moves)
+        replayed2 = _advance(start2, moves2)
+        assert replayed.board == replayed2.board
+
+
+def test_file_long_game_round_trip(tmp_path: Path) -> None:
+    """A 40-ply game's moves and end-state match across write/read.
+
+    Moves are pawn double-pushes on the four central ``(z, w)``-slices —
+    the only slices that carry both colors, so black has pieces to move
+    in response.
+    """
+    start = initial_position()
+    state = deepcopy(start)
+    moves: list[Move4D] = []
+    slices = [(3, 3), (3, 4), (4, 3), (4, 4)]
+    for z, w in slices:
+        for x in range(5):
+            white = Move4D(Square4D(x, 1, z, w), Square4D(x, 3, z, w))
+            moves.append(white)
+            state.push(white)
+            black = Move4D(Square4D(x, 6, z, w), Square4D(x, 4, z, w))
+            moves.append(black)
+            state.push(black)
+    assert len(moves) == 40
+
+    for ext in (".c4d", ".json"):
+        p = tmp_path / f"long{ext}"
+        write_game_file(p, start, moves)
+        start2, moves2 = read_game_file(p)
+        assert moves2 == moves
+        end = _advance(start2, moves2)
+        assert end.board == state.board
+        assert end.side_to_move is state.side_to_move
+        assert end.halfmove_clock == state.halfmove_clock
+
+
+def test_file_force_start_emits_header(tmp_path: Path) -> None:
+    start, moves = _two_pawn_game()
+    p = tmp_path / "game.c4d"
+    write_game_file(p, start, moves, force_start=True)
+    text = p.read_text(encoding="utf-8")
+    # First line should be a position header.
+    first_line = text.splitlines()[0]
+    assert first_line.startswith("w ")
+
+
+def test_file_accepts_str_path(tmp_path: Path) -> None:
+    start, moves = _two_pawn_game()
+    p = str(tmp_path / "game.c4d")
+    write_game_file(p, start, moves)
+    start2, moves2 = read_game_file(p)
+    assert moves2 == moves
+
+
+def test_file_uppercase_extension_is_recognized(tmp_path: Path) -> None:
+    start, moves = _two_pawn_game()
+    p = tmp_path / "GAME.C4D"
+    write_game_file(p, start, moves)
+    start2, moves2 = read_game_file(p)
+    assert moves2 == moves
+
+
+def test_file_malformed_content_reports_clearly(tmp_path: Path) -> None:
+    # A file with the right extension but garbage content.
+    p = tmp_path / "broken.json"
+    p.write_text('{"start": null, "moves":', encoding="utf-8")
+    with pytest.raises(NotationError) as exc_info:
+        read_game_file(p)
+    assert "invalid JSON" in str(exc_info.value)
+
+
+def test_file_malformed_compact_move_points_to_line(tmp_path: Path) -> None:
+    start, moves = _two_pawn_game()
+    p = tmp_path / "broken.c4d"
+    # Write the legit moves, then corrupt the last line.
+    text = render_compact_game(start, moves)
+    text += "garbage-line\n"
+    p.write_text(text, encoding="utf-8")
+    with pytest.raises(NotationError) as exc_info:
+        read_game_file(p)
+    # The error should mention a move index > 0.
+    assert "move #" in str(exc_info.value)

--- a/tests/test_notation_json.py
+++ b/tests/test_notation_json.py
@@ -1,0 +1,313 @@
+"""Phase 7C — JSON format (moves and positions)."""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, strategies as st
+
+from chess4d import (
+    BOARD_SIZE,
+    Board4D,
+    CastleSide,
+    Color,
+    GameState,
+    Move4D,
+    PawnAxis,
+    Piece,
+    PieceType,
+    Square4D,
+)
+from chess4d.notation import (
+    NotationError,
+    parse_json_move,
+    parse_json_position,
+    render_json_move,
+    render_json_position,
+)
+from chess4d.startpos import initial_position
+
+# Move round-trip -----------------------------------------------------------
+
+_coord = st.integers(min_value=0, max_value=BOARD_SIZE - 1)
+_sq = st.builds(Square4D, _coord, _coord, _coord, _coord)
+_promo = st.sampled_from(
+    [PieceType.QUEEN, PieceType.ROOK, PieceType.BISHOP, PieceType.KNIGHT]
+)
+
+
+def test_move_round_trip_ordinary() -> None:
+    m = Move4D(Square4D(0, 1, 2, 3), Square4D(0, 3, 2, 3))
+    assert parse_json_move(render_json_move(m)) == m
+
+
+def test_move_round_trip_promotion() -> None:
+    m = Move4D(Square4D(0, 6, 2, 3), Square4D(0, 7, 2, 3), promotion=PieceType.KNIGHT)
+    assert parse_json_move(render_json_move(m)) == m
+
+
+def test_move_round_trip_en_passant() -> None:
+    m = Move4D(Square4D(0, 4, 2, 3), Square4D(0, 5, 2, 3), is_en_passant=True)
+    assert parse_json_move(render_json_move(m)) == m
+
+
+def test_move_round_trip_castling() -> None:
+    m = Move4D(Square4D(4, 0, 2, 3), Square4D(6, 0, 2, 3), is_castling=True)
+    assert parse_json_move(render_json_move(m)) == m
+
+
+@given(from_sq=_sq, to_sq=_sq)
+def test_hypothesis_ordinary(from_sq: Square4D, to_sq: Square4D) -> None:
+    m = Move4D(from_sq, to_sq)
+    assert parse_json_move(render_json_move(m)) == m
+
+
+@given(from_sq=_sq, to_sq=_sq, promo=_promo)
+def test_hypothesis_promotion(
+    from_sq: Square4D, to_sq: Square4D, promo: PieceType
+) -> None:
+    m = Move4D(from_sq, to_sq, promotion=promo)
+    assert parse_json_move(render_json_move(m)) == m
+
+
+def test_move_defaults_on_missing_optional_fields() -> None:
+    js = '{"from":[0,0,0,0],"to":[0,1,0,0]}'
+    m = parse_json_move(js)
+    assert m.promotion is None
+    assert not m.is_castling
+    assert not m.is_en_passant
+
+
+# Move invalid inputs -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("bad", "fragment"),
+    [
+        ("not-json", "invalid JSON"),
+        ('[]', "must be a JSON object"),
+        ('{"from":[0,0,0,0]}', "missing required key 'to'"),
+        ('{"to":[0,0,0,0]}', "missing required key 'from'"),
+        ('{"from":"a1c4","to":[0,1,0,0]}', "must be a 4-element array"),
+        ('{"from":[0,0,0],"to":[0,1,0,0]}', "4-element array"),
+        ('{"from":[0,0,0,0,0],"to":[0,1,0,0]}', "4-element array"),
+        ('{"from":[0,0,0,8],"to":[0,1,0,0]}', "out of range"),
+        ('{"from":[0,0,0,-1],"to":[0,1,0,0]}', "out of range"),
+        ('{"from":[0,true,0,0],"to":[0,1,0,0]}', "must be an integer"),
+        (
+            '{"from":[0,0,0,0],"to":[0,1,0,0],"extra":1}',
+            "unexpected keys",
+        ),
+        (
+            '{"from":[0,0,0,0],"to":[0,1,0,0],"promotion":"PAWN"}',
+            "must be one of",
+        ),
+        (
+            '{"from":[0,0,0,0],"to":[0,1,0,0],"promotion":"KING"}',
+            "must be one of",
+        ),
+        (
+            '{"from":[0,0,0,0],"to":[0,1,0,0],"is_castling":"yes"}',
+            "must be a boolean",
+        ),
+    ],
+)
+def test_parse_json_move_invalid(bad: str, fragment: str) -> None:
+    with pytest.raises(NotationError) as exc_info:
+        parse_json_move(bad)
+    assert fragment in str(exc_info.value), (
+        f"expected fragment {fragment!r}, got {exc_info.value!s}"
+    )
+
+
+# Position round-trip -------------------------------------------------------
+
+
+def test_position_round_trip_initial() -> None:
+    gs = initial_position()
+    js = render_json_position(gs)
+    gs2 = parse_json_position(js)
+    assert gs2.board == gs.board
+    assert gs2.side_to_move is gs.side_to_move
+    assert gs2.castling_rights == gs.castling_rights
+    assert gs2.ep_target == gs.ep_target
+    assert gs2.ep_victim == gs.ep_victim
+    assert gs2.ep_axis == gs.ep_axis
+    assert gs2.halfmove_clock == gs.halfmove_clock
+
+
+def test_position_round_trip_empty_board() -> None:
+    gs = GameState(board=Board4D(), side_to_move=Color.WHITE)
+    js = render_json_position(gs)
+    gs2 = parse_json_position(js)
+    assert gs2.board == gs.board
+    assert gs2.side_to_move is Color.WHITE
+    assert gs2.castling_rights == frozenset()
+
+
+def test_position_round_trip_all_piece_types() -> None:
+    board = Board4D()
+    placements = [
+        (Square4D(0, 0, 0, 0), Piece(Color.WHITE, PieceType.ROOK)),
+        (Square4D(1, 0, 0, 0), Piece(Color.WHITE, PieceType.KNIGHT)),
+        (Square4D(2, 0, 0, 0), Piece(Color.WHITE, PieceType.BISHOP)),
+        (Square4D(3, 0, 0, 0), Piece(Color.WHITE, PieceType.QUEEN)),
+        (Square4D(4, 0, 0, 0), Piece(Color.WHITE, PieceType.KING)),
+        (Square4D(5, 0, 0, 0), Piece(Color.WHITE, PieceType.PAWN, PawnAxis.Y)),
+        (Square4D(6, 0, 0, 0), Piece(Color.WHITE, PieceType.PAWN, PawnAxis.W)),
+        (Square4D(0, 7, 0, 0), Piece(Color.BLACK, PieceType.KING)),
+        (Square4D(1, 7, 0, 0), Piece(Color.BLACK, PieceType.PAWN, PawnAxis.Y)),
+        (Square4D(2, 7, 0, 0), Piece(Color.BLACK, PieceType.PAWN, PawnAxis.W)),
+    ]
+    for sq, p in placements:
+        board.place(sq, p)
+    gs = GameState(board=board, side_to_move=Color.BLACK, halfmove_clock=42)
+    gs2 = parse_json_position(render_json_position(gs))
+    assert gs2.board == board
+    assert gs2.halfmove_clock == 42
+    assert gs2.side_to_move is Color.BLACK
+
+
+def test_position_round_trip_ep_state() -> None:
+    board = Board4D()
+    board.place(Square4D(4, 4, 3, 4), Piece(Color.BLACK, PieceType.PAWN, PawnAxis.W))
+    gs = GameState(
+        board=board,
+        side_to_move=Color.WHITE,
+        ep_target=Square4D(4, 4, 3, 5),
+        ep_victim=Square4D(4, 4, 3, 4),
+        ep_axis=PawnAxis.W,
+    )
+    gs2 = parse_json_position(render_json_position(gs))
+    assert gs2.ep_target == gs.ep_target
+    assert gs2.ep_victim == gs.ep_victim
+    assert gs2.ep_axis is PawnAxis.W
+
+
+def test_position_round_trip_castling_rights_subset() -> None:
+    rights = frozenset(
+        [
+            (Color.WHITE, 0, 0, CastleSide.KINGSIDE),
+            (Color.BLACK, 7, 7, CastleSide.QUEENSIDE),
+        ]
+    )
+    gs = GameState(
+        board=Board4D(), side_to_move=Color.WHITE, castling_rights=rights
+    )
+    gs2 = parse_json_position(render_json_position(gs))
+    assert gs2.castling_rights == rights
+
+
+def test_position_after_pawn_push_round_trips() -> None:
+    gs = initial_position()
+    gs.push(Move4D(Square4D(0, 1, 3, 3), Square4D(0, 3, 3, 3)))
+    gs2 = parse_json_position(render_json_position(gs))
+    assert gs2.board == gs.board
+    assert gs2.side_to_move is gs.side_to_move
+    assert gs2.ep_target == gs.ep_target
+    assert gs2.ep_victim == gs.ep_victim
+    assert gs2.ep_axis == gs.ep_axis
+
+
+# Position invalid inputs ---------------------------------------------------
+
+
+_VALID_MIN_POSITION = '{"placements":[],"side_to_move":"WHITE"}'
+
+
+@pytest.mark.parametrize(
+    ("bad", "fragment"),
+    [
+        ("not-json", "invalid JSON"),
+        ('[]', "must be a JSON object"),
+        ('{"side_to_move":"WHITE"}', "missing required key 'placements'"),
+        ('{"placements":[]}', "missing required key 'side_to_move'"),
+        (
+            '{"placements":[],"side_to_move":"PURPLE"}',
+            "must be one of",
+        ),
+        (
+            '{"placements":"nope","side_to_move":"WHITE"}',
+            "placements must be an array",
+        ),
+        (
+            '{"placements":[{"square":[0,0,0,0],"color":"WHITE","piece_type":"ROOK","pawn_axis":null,"extra":1}],"side_to_move":"WHITE"}',
+            "unexpected keys",
+        ),
+        (
+            '{"placements":[{"square":[0,0,0,0],"color":"WHITE","piece_type":"PAWN","pawn_axis":null}],"side_to_move":"WHITE"}',
+            "pawn_axis",
+        ),
+        (
+            '{"placements":[{"square":[0,0,0,0],"color":"WHITE","piece_type":"ROOK","pawn_axis":"Y"}],"side_to_move":"WHITE"}',
+            "pawn_axis",
+        ),
+        (
+            '{"placements":[],"side_to_move":"WHITE","halfmove_clock":"3"}',
+            "halfmove_clock must be an integer",
+        ),
+        (
+            '{"placements":[],"side_to_move":"WHITE","halfmove_clock":-1}',
+            "non-negative",
+        ),
+        (
+            '{"placements":[],"side_to_move":"WHITE","ep_target":[0,0,0,0]}',
+            "ep fields must be all null or all set",
+        ),
+        (
+            '{"placements":[],"side_to_move":"WHITE","extra":1}',
+            "unexpected keys",
+        ),
+        (
+            '{"placements":[],"side_to_move":"WHITE","castling_rights":[{"color":"WHITE","slice":[0,0],"side":"UP"}]}',
+            "must be one of",
+        ),
+        (
+            '{"placements":[],"side_to_move":"WHITE","castling_rights":[{"color":"WHITE","slice":[0,0,0],"side":"KINGSIDE"}]}',
+            "2-element array",
+        ),
+        (
+            '{"placements":[],"side_to_move":"WHITE","castling_rights":[{"color":"WHITE","slice":[0,0],"side":"KINGSIDE"},{"color":"WHITE","slice":[0,0],"side":"KINGSIDE"}]}',
+            "duplicates an earlier entry",
+        ),
+    ],
+)
+def test_parse_json_position_invalid(bad: str, fragment: str) -> None:
+    with pytest.raises(NotationError) as exc_info:
+        parse_json_position(bad)
+    assert fragment in str(exc_info.value), (
+        f"expected fragment {fragment!r}, got {exc_info.value!s}"
+    )
+
+
+def test_minimal_valid_position_parses() -> None:
+    gs = parse_json_position(_VALID_MIN_POSITION)
+    assert gs.board == Board4D()
+    assert gs.halfmove_clock == 0
+    assert gs.castling_rights == frozenset()
+
+
+# Unicode and whitespace handling (stdlib json handles these for us) --------
+
+
+def test_unicode_bom_parses_via_stdlib() -> None:
+    # json.loads rejects a real BOM in the string, but accepts surrounding
+    # ASCII whitespace including \t and \n.
+    js = "\n\t" + _VALID_MIN_POSITION + "\n"
+    gs = parse_json_position(js)
+    assert gs.side_to_move is Color.WHITE
+
+
+def test_placement_order_does_not_affect_parse() -> None:
+    board = Board4D()
+    board.place(Square4D(1, 0, 0, 0), Piece(Color.WHITE, PieceType.ROOK))
+    board.place(Square4D(0, 0, 0, 0), Piece(Color.WHITE, PieceType.KNIGHT))
+    gs = GameState(board=board, side_to_move=Color.WHITE)
+    # Shuffled order in the JSON source; parser should not care.
+    shuffled = (
+        '{"placements":['
+        '{"square":[1,0,0,0],"color":"WHITE","piece_type":"ROOK","pawn_axis":null},'
+        '{"square":[0,0,0,0],"color":"WHITE","piece_type":"KNIGHT","pawn_axis":null}'
+        '],"side_to_move":"WHITE"}'
+    )
+    gs2 = parse_json_position(shuffled)
+    assert gs2.board == gs.board


### PR DESCRIPTION
## Summary

- New `chess4d.notation` subpackage with two bidirectional serialization formats:
  - **Compact (Format A)** — human-readable coordinate notation. A square is four chars `letter-digit-letter-digit` (`a1c4` = `x=0, y=0, z=2, w=3`). Castling encodes color by case (`O-O@c4` white, `o-o@c4` black) so the parser is self-contained.
  - **JSON (Format B)** — explicit `Move4D` / `GameState` shapes, strict on unknown keys and type mismatches.
- **Game format** omits the start block when equivalent to `initial_position()` (or `"start": null` in JSON); `force_start=True` overrides.
- **File I/O** infers format from extension (`.c4d` / `.c4dpos` / `.json`); `format=` kwarg overrides. Covers both game and position files.
- **Top-level auto-detect API** — `parse_move` / `render_move` / `parse_position` / `render_position` / `parse_game` / `render_game`. Detection is by leading non-whitespace char: `{` → JSON, else compact.

## Phased layout

- **7A** compact move parser/renderer
- **7B** compact position parser/renderer (en-passant victim/axis reconstructed from the board)
- **7C** JSON move + position (explicit `ep_target`/`ep_victim`/`ep_axis` — all-or-nothing)
- **7D** game format + file I/O
- **7E** top-level auto-detect API

## Why

The paper's reference JS engine ships no notation format and no public 4D-chess notation exists in referenceable form; this establishes the reference formats for Python tooling. Compact is for eyeballing / hand-authoring; JSON is for interchange and tests.

## Test plan

- [x] 165 new tests across move / position / game / auto-detect round trips and invalid-input parametrization
- [x] Pytest full suite: **608 passed**, 3 deselected
- [x] Slow suite: **3 passed** (4m20s)
- [x] mypy clean (21 source files)
- [x] ruff clean

## Notes for reviewer

- `render_compact_game` replays moves on a deep copy of the start to pick the `x` vs `-` capture separator; illegal move lists surface through the normal `GameState.push` `IllegalMoveError`.
- `GameState.position_history` is deliberately not serialized — it's runtime-reconstructed during replay.
- Castling rights canonical sort: `(int(color), z, w, int(side))` → `Wa1K,Wa1Q,Wa2K,...`
- Position rank order is ascending `y` (`y=0` first), matching internal indexing rather than FEN convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)