### PR TITLE
Phase 8: chess-spectral encoder integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,48 @@ Pre-alpha. Currently implemented: core types (`Square4D`, `Move4D`,
 `Piece`, `Color`, `PieceType`, `PawnAxis`). Rook move generation and
 invariant tests are next. Other pieces and the legality pipeline are stubs.
 
+## Spectral encoding (optional)
+
+chess4d integrates with the `chess-spectral` framework (developed in the
+sibling `mlehaptics` repo) for physics-grounded analysis of 4D positions.
+The encoder maps a `GameState` to an 11-channel, 45 056-dimensional
+float32 spectral vector and writes streams of frames as `spectralz` v4
+files. Install with the `spectral` extra (pulls `chess-spectral` directly
+from GitHub, plus numpy and scipy):
+
+```bash
+pip install -e .[spectral]
+```
+
+Encode a single position:
+
+```python
+from chess4d import initial_position
+from chess4d.spectral import encode_position
+
+gs = initial_position()
+vec = encode_position(gs)  # (45056,) float32
+```
+
+Encode a game and write it to a `spectralz` v4 file:
+
+```python
+from chess4d.spectral import write_spectralz
+
+write_spectralz("game.spectralz", start_state, move_list)
+```
+
+Generate a reproducible random-playout corpus:
+
+```bash
+chess4d-corpus-gen --n-games 10 --seed 42 --output ./corpus
+```
+
+The 11 channels cover the six piece types (with pawns split by forward
+axis per Oana & Chiru Def. 11) plus board-parity and side-to-move
+signals. See the `chess-spectral` notebooks in the mlehaptics repo for
+channel semantics and reconstruction examples.
+
 ## Development
 
 ```bash

--- a/examples/encode_hello_4d.py
+++ b/examples/encode_hello_4d.py
@@ -1,0 +1,46 @@
+"""Smoke example for the chess4d ⇄ chess-spectral adapter.
+
+Plays five random moves from the Oana-Chiru starting position, writes a
+``spectralz`` v4 file to ``hello.spectralz`` in the current directory,
+reads it back, and prints a one-line summary.
+
+Run::
+
+    python examples/encode_hello_4d.py
+"""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+from chess4d import initial_position
+from chess4d.spectral import write_spectralz
+from chess_spectral.frame_4d import read_spectralz_v4
+
+
+def main() -> None:
+    rng = random.Random(0)
+    gs = initial_position()
+    moves = []
+    for _ in range(5):
+        legal = list(gs.legal_moves())
+        if not legal:
+            break
+        move = rng.choice(legal)
+        gs.push(move)
+        moves.append(move)
+
+    out = Path("hello.spectralz")
+    nbytes = write_spectralz(out, initial_position(), moves)
+    header, frames = read_spectralz_v4(out)
+
+    print(
+        f"wrote {out} ({nbytes} bytes): version={header.version} "
+        f"encoding_dim={header.encoding_dim} n_plies={header.n_plies} "
+        f"frames_read={len(frames)}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,15 @@ dev = [
     "mypy>=1.8",
     "ruff>=0.4",
 ]
+spectral = [
+    # chess-spectral v1.1.1 (45 056-dim 4D encoder + spectralz v4 frame format)
+    # lives as a subdirectory inside the mlehaptics monorepo. Pinned to the
+    # main-HEAD commit where v1.1.1 shipped.
+    "chess-spectral @ git+https://github.com/lemonforest/mlehaptics.git@adc3b86fdd4636a1dd4541ce2734a4b1498e8545#subdirectory=docs/chess-maths/chess-spectral/python",
+]
+
+[project.scripts]
+chess4d-corpus-gen = "chess4d.corpus:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/chess4d/corpus.py
+++ b/src/chess4d/corpus.py
@@ -1,0 +1,165 @@
+"""Random-playout corpus generation (Phase 8).
+
+Produces spectralz v4 files from random legal playouts off the
+Oana-Chiru starting position. Used for downstream empirical work —
+measuring F_D fingerprints, verifying spectral predictions against
+engine data, building tiny training sets.
+
+Entry points::
+
+    chess4d.corpus.generate_corpus(n_games=N, seed=S, ...) -> list[Path]
+
+and, via ``[project.scripts]``::
+
+    chess4d-corpus-gen --n-games 10 --seed 42 --output ./corpus
+
+The CLI also runs via ``python -m chess4d.corpus``. Termination
+reasons ("checkmate" / "stalemate" / "max_plies") are logged to stderr
+and returned in the per-game summary so the caller can tally them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from chess4d.spectral import write_spectralz
+from chess4d.startpos import initial_position
+from chess4d.types import Move4D
+
+
+__all__ = ["GameSummary", "generate_corpus", "main", "play_random_game"]
+
+
+@dataclass(frozen=True)
+class GameSummary:
+    """One row of per-game stats from :func:`generate_corpus`.
+
+    ``termination`` is one of ``"checkmate"``, ``"stalemate"``, or
+    ``"max_plies"``. ``bytes_written`` is the spectralz file size
+    reported by :func:`write_spectralz`.
+    """
+
+    path: Path
+    plies: int
+    termination: str
+    bytes_written: int
+
+
+def play_random_game(
+    rng: random.Random, max_plies: int
+) -> tuple[list[Move4D], str]:
+    """Play a uniformly-random legal game and return ``(moves, termination)``.
+
+    Stops at checkmate, stalemate, or ``max_plies``. The engine's
+    full legality pipeline (§3.4 Def 3) is honored on every ply via
+    :meth:`GameState.legal_moves`, so the resulting move list is
+    always a valid Oana-Chiru game prefix.
+    """
+    gs = initial_position()
+    moves: list[Move4D] = []
+    for _ in range(max_plies):
+        legal = list(gs.legal_moves())
+        if not legal:
+            return moves, "checkmate" if gs.in_check() else "stalemate"
+        move = rng.choice(legal)
+        gs.push(move)
+        moves.append(move)
+    return moves, "max_plies"
+
+
+def generate_corpus(
+    n_games: int,
+    *,
+    max_plies: int = 200,
+    seed: Optional[int] = None,
+    output_dir: str | Path = "./corpus",
+) -> list[GameSummary]:
+    """Generate ``n_games`` random-playout spectralz v4 files.
+
+    ``seed`` fully determines the output: two calls with the same
+    ``(n_games, max_plies, seed)`` write byte-identical files. Files
+    are named ``game_001.spectralz`` through ``game_{n_games:03d}
+    .spectralz``; the output directory is created if absent.
+    """
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    rng = random.Random(seed)
+    summaries: list[GameSummary] = []
+    for i in range(1, n_games + 1):
+        moves, termination = play_random_game(rng, max_plies)
+        path = out / f"game_{i:03d}.spectralz"
+        start = initial_position()
+        nbytes = write_spectralz(path, start, moves)
+        summaries.append(
+            GameSummary(
+                path=path,
+                plies=len(moves),
+                termination=termination,
+                bytes_written=nbytes,
+            )
+        )
+        print(
+            f"game_{i:03d}: plies={len(moves):4d} "
+            f"term={termination:10s} bytes={nbytes}",
+            file=sys.stderr,
+        )
+    return summaries
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="chess4d-corpus-gen",
+        description="Generate a corpus of spectralz v4 files from random "
+        "Oana-Chiru playouts.",
+    )
+    parser.add_argument(
+        "--n-games", type=int, default=10, help="Number of games to generate."
+    )
+    parser.add_argument(
+        "--max-plies",
+        type=int,
+        default=200,
+        help="Cap on plies per game before forcing termination.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Random seed for reproducibility (omit for nondeterministic).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("./corpus"),
+        help="Directory to write game_NNN.spectralz files into.",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """CLI entry point. Returns the process exit code."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    summaries = generate_corpus(
+        n_games=args.n_games,
+        max_plies=args.max_plies,
+        seed=args.seed,
+        output_dir=args.output,
+    )
+    total_bytes = sum(s.bytes_written for s in summaries)
+    total_plies = sum(s.plies for s in summaries)
+    print(
+        f"wrote {len(summaries)} games, {total_plies} plies, "
+        f"{total_bytes} bytes to {args.output}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/chess4d/spectral.py
+++ b/src/chess4d/spectral.py
@@ -1,0 +1,211 @@
+"""chess4d ⇄ chess-spectral adapter (Phase 8).
+
+Bridges :class:`chess4d.GameState` into the ``chess_spectral`` 4D
+encoder and the ``spectralz`` v4 frame format. The encoder itself lives
+in the sibling mlehaptics repository and is installed via the optional
+``[spectral]`` extra.
+
+Three public entry points::
+
+    gamestate_to_pos4(gs)        -> dict keyed by linear square index
+    encode_position(gs)          -> (45056,) float32 numpy array
+    encode_game(start, moves)    -> iterator of (GameState, ndarray)
+    write_spectralz(path, ...)   -> int bytes written, spectralz v4
+
+Pawn value convention follows the v1.1.1 Oana-Chiru schema documented
+on :func:`chess_spectral.encoder_4d.encode_4d`: pawns are emitted as
+``(color_char, axis_char)`` tuples, never as bare single chars (the
+legacy form emits a ``DeprecationWarning`` and is avoided here).
+
+Import drift note: the project spec references
+``chess_spectral_4d.encode_4d`` and ``chess_spectral_4d.frame_4d``, but
+in the v1.1.1 package layout ``chess_spectral_4d`` only re-exports
+constants. The real encoder is ``chess_spectral.encoder_4d.encode_4d``
+and the writer is ``chess_spectral.frame_4d.write_spectralz_v4``; those
+are what this module imports.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import TYPE_CHECKING, Iterable, Iterator, Union
+
+try:
+    from chess_spectral.encoder_4d import (  # type: ignore[import-untyped]
+        ENCODING_DIM_4D,
+        encode_4d,
+    )
+    from chess_spectral.frame_4d import (  # type: ignore[import-untyped]
+        Frame4D,
+        read_spectralz_v4,
+        write_spectralz_v4,
+    )
+except ImportError as e:  # pragma: no cover — exercised only without extra
+    raise ImportError(
+        "chess4d.spectral requires the 'spectral' extra. "
+        "Install with: pip install chess4d[spectral]"
+    ) from e
+
+from chess4d.state import GameState
+from chess4d.types import Color, Move4D, PieceType, Square4D
+
+if TYPE_CHECKING:
+    import numpy as np
+
+
+__all__ = [
+    "ENCODING_DIM_4D",
+    "Frame4D",
+    "encode_game",
+    "encode_position",
+    "gamestate_to_pos4",
+    "read_spectralz_v4",
+    "write_spectralz",
+]
+
+
+PieceValue = Union[str, tuple[str, str]]
+
+_NONPAWN_CHAR: dict[PieceType, str] = {
+    PieceType.KNIGHT: "N",
+    PieceType.BISHOP: "B",
+    PieceType.ROOK: "R",
+    PieceType.QUEEN: "Q",
+    PieceType.KING: "K",
+}
+
+
+def _linear_index(sq: Square4D) -> int:
+    """Encoder's linear square index: ``(x<<9) | (y<<6) | (z<<3) | w``.
+
+    Matches the ordering used internally by :func:`encode_4d` to lay
+    out the 4096 board squares across the 11 spectral channels.
+    """
+    return (sq.x << 9) | (sq.y << 6) | (sq.z << 3) | sq.w
+
+
+def gamestate_to_pos4(gs: GameState) -> dict[int, PieceValue]:
+    """Translate a :class:`GameState` into the encoder's ``pos4`` dict.
+
+    Empty squares are omitted. Pawns are always emitted as
+    ``(color_char, axis_char)`` tuples per the v1.1.1 Oana-Chiru
+    schema; non-pawn pieces are single characters, uppercase for
+    White and lowercase for Black.
+
+    Raises :class:`ValueError` for a pawn without a ``pawn_axis`` (the
+    :class:`~chess4d.types.Piece` invariant should make this
+    unreachable) or for an unrecognized ``piece_type``.
+    """
+    pos4: dict[int, PieceValue] = {}
+    for color in (Color.WHITE, Color.BLACK):
+        uppercase = color is Color.WHITE
+        for sq, piece in gs.board.pieces_of(color):
+            key = _linear_index(sq)
+            if piece.piece_type is PieceType.PAWN:
+                if piece.pawn_axis is None:
+                    raise ValueError(
+                        f"Pawn at {sq} has no pawn_axis; cannot encode."
+                    )
+                color_char = "P" if uppercase else "p"
+                axis_char = piece.pawn_axis.name.lower()
+                pos4[key] = (color_char, axis_char)
+                continue
+            base = _NONPAWN_CHAR.get(piece.piece_type)
+            if base is None:
+                raise ValueError(
+                    f"Unrecognized piece_type {piece.piece_type!r} at {sq}."
+                )
+            pos4[key] = base if uppercase else base.lower()
+    return pos4
+
+
+def encode_position(gs: GameState) -> "np.ndarray":
+    """Encode a single :class:`GameState` as a ``(45056,)`` float32 vector."""
+    result: "np.ndarray" = encode_4d(gamestate_to_pos4(gs))
+    return result
+
+
+def encode_game(
+    start: GameState, moves: Iterable[Move4D]
+) -> Iterator[tuple[GameState, "np.ndarray"]]:
+    """Replay ``moves`` from ``start``, yielding ``(state, encoding)`` per ply.
+
+    The initial state is yielded first (ply 0) and then once per
+    applied move, giving ``len(moves) + 1`` pairs for a finite
+    iterable. ``start`` is deep-copied up front; the caller's state
+    object is left untouched.
+    """
+    current = copy.deepcopy(start)
+    yield current, encode_position(current)
+    for move in moves:
+        current.push(move)
+        yield current, encode_position(current)
+
+
+def _move_to_coords(
+    move: Move4D | None,
+) -> tuple[tuple[int, int, int, int], tuple[int, int, int, int], int]:
+    """Return ``(from_coord, to_coord, promo_int)`` for a :class:`Frame4D`.
+
+    The sentinel for "no move" (used on the ply-0 frame) is the
+    zero-tuple pair with ``promo=0``, which is the same pattern the
+    spectralz writer uses internally when a frame is synthesized from
+    an initial position.
+    """
+    if move is None:
+        return (0, 0, 0, 0), (0, 0, 0, 0), 0
+    promo = int(move.promotion) if move.promotion is not None else 0
+    return (
+        (move.from_sq.x, move.from_sq.y, move.from_sq.z, move.from_sq.w),
+        (move.to_sq.x, move.to_sq.y, move.to_sq.z, move.to_sq.w),
+        promo,
+    )
+
+
+def _move_flags(move: Move4D | None) -> int:
+    """Pack ``is_castling`` and ``is_en_passant`` into the frame ``flags`` byte.
+
+    Bit 0 = castling, bit 1 = en passant. The spectralz format reserves
+    the full byte; higher bits are available for future semantics.
+    """
+    if move is None:
+        return 0
+    flags = 0
+    if move.is_castling:
+        flags |= 1 << 0
+    if move.is_en_passant:
+        flags |= 1 << 1
+    return flags
+
+
+def write_spectralz(
+    path: str | Path,
+    start: GameState,
+    moves: Iterable[Move4D],
+) -> int:
+    """Encode a game and write it as a spectralz v4 file. Returns bytes written.
+
+    The first frame is the ply-0 initial state with a zero-move
+    sentinel; subsequent frames carry the applied move's geometry and
+    flags. ``moves`` is consumed eagerly so the writer can report
+    ``n_plies`` in the header before streaming frames.
+    """
+    move_list = list(moves)
+    frames: list[Frame4D] = []
+    prev_move: Move4D | None = None
+    for ply, (_, encoding) in enumerate(encode_game(start, move_list)):
+        from_c, to_c, promo = _move_to_coords(prev_move)
+        frames.append(
+            Frame4D(
+                encoding=encoding,
+                ply=ply,
+                from_sq=from_c,
+                to_sq=to_c,
+                promo=promo,
+                flags=_move_flags(prev_move),
+            )
+        )
+        prev_move = move_list[ply] if ply < len(move_list) else None
+    nbytes: int = write_spectralz_v4(path, frames)
+    return nbytes

--- a/tests/test_spectral.py
+++ b/tests/test_spectral.py
@@ -1,0 +1,238 @@
+"""Phase 8 — chess-spectral adapter and spectralz v4 round-trip.
+
+Skipped as a module when the ``spectral`` extra isn't installed. When
+it is, these cover:
+
+* pos4 translation: pawn tuple values, axis mapping, non-pawn chars
+* single-position encoding smoke (shape / dtype / determinism)
+* game replay counts (N+1 frames for N moves)
+* spectralz v4 round-trip via :func:`read_spectralz_v4`
+* tiny corpus reproducibility with a fixed seed
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("chess_spectral")
+
+import numpy as np
+
+from chess4d import (
+    Board4D,
+    Color,
+    GameState,
+    Move4D,
+    PawnAxis,
+    Piece,
+    PieceType,
+    Square4D,
+    initial_position,
+)
+from chess4d.corpus import generate_corpus
+from chess4d.spectral import (
+    ENCODING_DIM_4D,
+    encode_game,
+    encode_position,
+    gamestate_to_pos4,
+    write_spectralz,
+)
+
+from chess_spectral.frame_4d import read_spectralz_v4
+
+
+# 4a. Position translation --------------------------------------------------
+
+
+def test_initial_position_entry_count() -> None:
+    gs = initial_position()
+    pos4 = gamestate_to_pos4(gs)
+    # Paper §3.3: 28 populated (z,w)-slices × 16 pieces per color × 2 colors.
+    assert len(pos4) == 896
+
+
+def test_initial_position_pawn_nonpawn_split() -> None:
+    gs = initial_position()
+    pos4 = gamestate_to_pos4(gs)
+    pawns = [v for v in pos4.values() if isinstance(v, tuple)]
+    nonpawns = [v for v in pos4.values() if isinstance(v, str)]
+    assert len(pawns) == 448
+    assert len(nonpawns) == 448
+
+
+def test_pawn_values_are_tuples_not_chars() -> None:
+    gs = initial_position()
+    pos4 = gamestate_to_pos4(gs)
+    for v in pos4.values():
+        if isinstance(v, tuple):
+            color_char, axis_char = v
+            assert color_char in ("P", "p")
+            assert axis_char in ("y", "w")
+
+
+def test_nonpawn_chars_uppercase_for_white_lowercase_for_black() -> None:
+    gs = initial_position()
+    pos4 = gamestate_to_pos4(gs)
+    # White back rank lives on y=0 (slice (3,3) is central); Black on y=7.
+    white_rook = Square4D(0, 0, 3, 3)
+    black_rook = Square4D(0, 7, 3, 3)
+    wkey = (white_rook.x << 9) | (white_rook.y << 6) | (white_rook.z << 3) | white_rook.w
+    bkey = (black_rook.x << 9) | (black_rook.y << 6) | (black_rook.z << 3) | black_rook.w
+    assert pos4[wkey] == "R"
+    assert pos4[bkey] == "r"
+
+
+def test_w_oriented_pawn_maps_to_w_axis_char() -> None:
+    board = Board4D()
+    board.place(
+        Square4D(3, 0, 3, 1),
+        Piece(color=Color.WHITE, piece_type=PieceType.PAWN, pawn_axis=PawnAxis.W),
+    )
+    gs = GameState(board=board, side_to_move=Color.WHITE)
+    pos4 = gamestate_to_pos4(gs)
+    (value,) = pos4.values()
+    assert value == ("P", "w")
+
+
+def test_y_oriented_pawn_maps_to_y_axis_char() -> None:
+    board = Board4D()
+    board.place(
+        Square4D(3, 1, 3, 3),
+        Piece(color=Color.BLACK, piece_type=PieceType.PAWN, pawn_axis=PawnAxis.Y),
+    )
+    gs = GameState(board=board, side_to_move=Color.BLACK)
+    pos4 = gamestate_to_pos4(gs)
+    (value,) = pos4.values()
+    assert value == ("p", "y")
+
+
+def test_linear_index_bit_packing() -> None:
+    # Hand-compute one square: (x=1, y=2, z=3, w=4)
+    #   = (1<<9) | (2<<6) | (3<<3) | 4 = 512 + 128 + 24 + 4 = 668
+    board = Board4D()
+    board.place(
+        Square4D(1, 2, 3, 4),
+        Piece(color=Color.WHITE, piece_type=PieceType.KNIGHT),
+    )
+    gs = GameState(board=board, side_to_move=Color.WHITE)
+    pos4 = gamestate_to_pos4(gs)
+    assert pos4 == {668: "N"}
+
+
+# 4b. Encoding smoke tests --------------------------------------------------
+
+
+def test_encode_position_shape_and_dtype() -> None:
+    vec = encode_position(initial_position())
+    assert vec.shape == (ENCODING_DIM_4D,) == (45056,)
+    assert vec.dtype == np.float32
+
+
+def test_encode_position_nonzero() -> None:
+    vec = encode_position(initial_position())
+    assert float(np.abs(vec).sum()) > 0.0
+
+
+def test_encode_position_deterministic() -> None:
+    a = encode_position(initial_position())
+    b = encode_position(initial_position())
+    assert np.array_equal(a, b)
+
+
+# 4c. Game replay -----------------------------------------------------------
+
+
+def test_encode_game_empty_moves_yields_one_pair() -> None:
+    pairs = list(encode_game(initial_position(), []))
+    assert len(pairs) == 1
+    state, enc = pairs[0]
+    assert enc.shape == (45056,)
+    # The caller-passed state must be untouched after deepcopy.
+    assert state is not None
+
+
+def test_encode_game_yields_n_plus_one_pairs() -> None:
+    start = initial_position()
+    # Two simple Y-pawn pushes on opposite sides of a central slice.
+    m1 = Move4D(Square4D(0, 1, 3, 3), Square4D(0, 3, 3, 3))
+    m2 = Move4D(Square4D(0, 6, 3, 3), Square4D(0, 4, 3, 3))
+    pairs = list(encode_game(start, [m1, m2]))
+    assert len(pairs) == 3
+    for _, enc in pairs:
+        assert enc.shape == (45056,)
+        assert enc.dtype == np.float32
+
+
+def test_encode_game_does_not_mutate_start() -> None:
+    start = initial_position()
+    before = gamestate_to_pos4(start)
+    m = Move4D(Square4D(0, 1, 3, 3), Square4D(0, 3, 3, 3))
+    list(encode_game(start, [m]))
+    after = gamestate_to_pos4(start)
+    assert before == after
+
+
+# 4d. Spectralz v4 round-trip ----------------------------------------------
+
+
+def test_write_spectralz_round_trip(tmp_path: Path) -> None:
+    start = initial_position()
+    moves = [
+        Move4D(Square4D(0, 1, 3, 3), Square4D(0, 3, 3, 3)),
+        Move4D(Square4D(0, 6, 3, 3), Square4D(0, 4, 3, 3)),
+    ]
+    path = tmp_path / "round_trip.spectralz"
+    nbytes = write_spectralz(path, start, moves)
+    assert nbytes > 0
+    assert path.stat().st_size == nbytes
+
+    header, frames = read_spectralz_v4(path)
+    assert header.version == 4
+    assert header.encoding_dim == 45056
+    assert header.n_plies == len(moves) + 1
+    assert len(frames) == len(moves) + 1
+
+    # Each frame's encoding matches encode_position bit-exactly.
+    expected = [enc for _, enc in encode_game(start, moves)]
+    for frame, want in zip(frames, expected):
+        assert np.array_equal(frame.encoding, want)
+
+
+def test_write_spectralz_initial_frame_has_zero_move(tmp_path: Path) -> None:
+    path = tmp_path / "init_frame.spectralz"
+    write_spectralz(path, initial_position(), [])
+    _, frames = read_spectralz_v4(path)
+    assert len(frames) == 1
+    f0 = frames[0]
+    assert f0.ply == 0
+    assert f0.from_sq == (0, 0, 0, 0)
+    assert f0.to_sq == (0, 0, 0, 0)
+    assert f0.promo == 0
+
+
+# 4e. Corpus smoke ----------------------------------------------------------
+
+
+def test_generate_corpus_produces_requested_files(tmp_path: Path) -> None:
+    summaries = generate_corpus(
+        n_games=3, max_plies=10, seed=42, output_dir=tmp_path
+    )
+    assert len(summaries) == 3
+    for s in summaries:
+        assert s.path.exists()
+        assert s.bytes_written > 0
+        header, _ = read_spectralz_v4(s.path)
+        assert header.version == 4
+
+
+def test_generate_corpus_is_reproducible_with_seed(tmp_path: Path) -> None:
+    a_dir = tmp_path / "run_a"
+    b_dir = tmp_path / "run_b"
+    generate_corpus(n_games=3, max_plies=10, seed=42, output_dir=a_dir)
+    generate_corpus(n_games=3, max_plies=10, seed=42, output_dir=b_dir)
+    for i in range(1, 4):
+        a = (a_dir / f"game_{i:03d}.spectralz").read_bytes()
+        b = (b_dir / f"game_{i:03d}.spectralz").read_bytes()
+        assert a == b


### PR DESCRIPTION
## Summary

- Wires `chess4d.GameState` into the `chess-spectral` v1.1.1 4D encoder (45 056-dim, 11 channels) and the `spectralz` v4 frame format.
- Makes `chess-spectral` an opt-in dependency via a new `[spectral]` extra so the core engine keeps zero runtime deps.
- Adds a seeded random-playout corpus generator exposed as a `chess4d-corpus-gen` console script.

## Files

- `src/chess4d/spectral.py` — `gamestate_to_pos4`, `encode_position`, `encode_game`, `write_spectralz`. Pawns emit the v1.1.1 Oana-Chiru `(color_char, axis_char)` tuple form; non-pawns emit uppercase/lowercase single chars.
- `src/chess4d/corpus.py` — `generate_corpus` + CLI entry point.
- `tests/test_spectral.py` — 17 tests (auto-skipped when the extra isn't installed).
- `examples/encode_hello_4d.py` — 5-move smoke.
- `pyproject.toml` — `[spectral]` extra + `chess4d-corpus-gen` script entry.
- `README.md` — optional `[spectral]` section.

## Test results

- Full suite: **625 passed, 3 deselected** (the 3 deselected are the `slow` markers from the notation-file and legal-moves parity tests).
- New spectral tests: **17 passed** in ~135s.
- `mypy --strict src/chess4d`: clean (23 files).
- `ruff check src tests examples`: clean.
- `examples/encode_hello_4d.py`: writes a 1 081 684-byte `hello.spectralz` with 6 frames, reads back cleanly.

## 3-game seeded corpus smoke (`--seed 42 --max-plies 40`)

```
game_001: plies=  40 term=max_plies  bytes=7390014
game_002: plies=  40 term=max_plies  bytes=7390014
game_003: plies=  40 term=max_plies  bytes=7390014
wrote 3 games, 120 plies, 22170042 bytes to _pr_smoke_corpus
```

The test suite also asserts byte-for-byte reproducibility across two runs with the same seed.

## API drift from the integration spec

Three discrepancies between the spec in `hoodoos/brokenpaste.md` and the installed `chess-spectral 1.1.1`; all were resolved in favor of the installed layout (no encoder changes):

1. **`encode_4d` lives at `chess_spectral.encoder_4d`, not `chess_spectral_4d`.** In v1.1.1, `chess_spectral_4d` only re-exports constants (`ENCODING_DIM_4D`, `N_CHANNELS_4D`, offsets, `VERSION`).
2. **The spectralz v4 writer lives at `chess_spectral.frame_4d.write_spectralz_v4`**, not `chess_spectral_4d.frame_4d`. `Frame4D`, `Header4D`, and `read_spectralz_v4` live there too.
3. **Commit pin: `adc3b86f`, not `518a973`.** The spec's suggested hash doesn't exist in `lemonforest/mlehaptics`; the current `main` HEAD is where v1.1.1 ships per the subdir's `pyproject.toml`.

## Adapter notes

- `encode_game` deep-copies the caller's `start` state before replaying moves so the caller's `GameState` is never mutated (a Phase-8 test covers this explicitly).
- `write_spectralz` uses the zero-tuple `from_sq`/`to_sq` + `promo=0` convention for the initial ply-0 frame; move flags pack `is_castling` (bit 0) and `is_en_passant` (bit 1) into the frame's `flags` byte.
- `gamestate_to_pos4` raises `ValueError` on a pawn with `pawn_axis is None` (shouldn't happen thanks to `Piece.__post_init__`) or on an unrecognized `PieceType` — defensive, future-proofs against enum additions.

## Test plan

- [x] `pip install -e .[spectral]` in a fresh venv, then `python -m pytest tests/test_spectral.py -v`.
- [x] `chess4d-corpus-gen --n-games 3 --seed 42 --max-plies 20 --output ./smoke_corpus`.
- [x] `python examples/encode_hello_4d.py` — confirm `hello.spectralz` round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)