### PR TITLE
Fix: allow-direct-references so [spectral] extra installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,13 @@ chess4d-corpus-gen = "chess4d.corpus:main"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.metadata]
+# The [spectral] extra pins chess-spectral to a git+https URL (a PEP 508
+# "direct reference"). Hatchling rejects those by default as a safety
+# measure; this opt-in is required to accept the spectralz-v4 encoder's
+# mlehaptics-subdir install source.
+allow-direct-references = true
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/chess4d"]
 


### PR DESCRIPTION
## Summary

Phase 8's pyproject.toml declared the `[spectral]` extra via a git+https direct reference but didn't enable hatchling's `allow-direct-references` opt-in. As a result, **any** `pip install -e .[...]` (even just `[dev]`) fails at metadata prep with:

> `ValueError: Dependency #1 of option \`spectral\` of field \`project.optional-dependencies\` cannot be a direct reference unless field \`tool.hatch.metadata.allow-direct-references\` is set to \`true\``

This one-line fix adds the required `[tool.hatch.metadata]` block.

## Verification

Against the venv at `.venv\`:

```
> pip install -e . --no-deps
Successfully installed python-chess4d-oana-chiru-0.1.0

> chess4d-corpus-gen --help
usage: chess4d-corpus-gen [-h] [--n-games N_GAMES] [--max-plies MAX_PLIES] ...
```

The console-script entry point from Phase 8 now registers correctly.

## Test plan

- [x] `pip install -e .[spectral]` succeeds in a fresh venv. Might need `git config --global core.longpaths true`
- [x] `chess4d-corpus-gen --n-games 1 --seed 42 --output ./smoke` writes a spectralz file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)