### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-chess4d-oana-chiru"
-version = "0.1.0"
+version = "0.1.1"
 description = "Python reference implementation of Oana & Chiru (2026) — A Mathematical Framework for Four-Dimensional Chess (DOI 10.3390/appliedmath6030048)."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Stamp the post-fix baseline as `0.1.1`. [PR #5](https://github.com/lemonforest/python-chess4d-oana-chiru/pull/5) corrected pawn axis alternation in `initial_position()` to match Oana & Chiru §3.3 / Def 11. Smoke corpora generated against this baseline now have a distinguishable version from the pre-fix `0.1.0` output.

## Test plan

- [x] `pyproject.toml` version string updated
- [x] After merge: tag `v0.1.1` on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)