### PR TITLE
Restructure corpus to nested <run_id>/ layout with NDJSON snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] — 2026-04-19
+
+Corpus restructure: nested `<run_id>/` layout, NDJSON per-ply snapshots,
+and full `manifest.json` schema — drops into the `chess-maths-the-movie`
+toolchain alongside the 2D chess spectral viewer.
+
+### Added
+
+- Nested corpus layout: `<output>/<run_id>/{manifest.json, c4d/, ndjson/, spectralz/}`.
+- NDJSON schema `chess4d-ndjson-v1` — format header + game header + per-ply
+  records carrying a `pos4` dict (2-char pawn values `Pw`/`Py`/`pw`/`py`,
+  1-char non-pawns), keyed by the linear square index
+  `(x<<9) | (y<<6) | (z<<3) | w`.
+- `manifest.json` top-level schema: `generated_utc`, `run_id`, `source`,
+  `fetch_params`, `tool_versions`, `aggregates`, `games[]`.
+- `CorpusResult` dataclass returned from `generate_corpus()`; `GameSummary`
+  gains `stem`, `c4d_path`, `ndjson_path`, `encoding_path`, `plies`,
+  `encoded_plies`, `pivot_ply`, `termination`, and matching byte-count fields.
+- Auto-generated `run_id` of the form `corpus_YYYYMMDD_HHMMSS_seedN` (or
+  `..._unseeded`); override via the `--run-id` CLI flag or `run_id=` kwarg.
+- `write_spectralz(..., base_ply=N)` kwarg: frame `ply` numbers are written
+  with an absolute offset, so tail-encoded spectralz files join cleanly
+  against the full-game NDJSON by absolute ply.
+- `--no-encode` CLI flag runs the full corpus pipeline on a bare install
+  without the `[spectral]` extra (`chess_spectral` import is lazy).
+- `NDJSON_FORMAT_ID` and `_auto_run_id` exposed as module-level names for
+  reuse in downstream tools.
+
+### Changed
+
+- `generate_corpus()` now returns `CorpusResult` (previously
+  `list[GameSummary]`). Callers iterating the return value should switch
+  to `result.games`.
+- Flat `game_NNN.{json,spectralz}` output layout from the in-progress
+  branch has been replaced by the nested `<run_id>/` layout before
+  landing — no released version exposed the flat form.
+
+### Fixed
+
+- Manifest byte-count fields now match on-disk file sizes on Windows,
+  where `Path.write_text` translates `\n` to `\r\n`. Writers now report
+  `Path.stat().st_size` instead of `len(text.encode("utf-8"))`.
+- `manifest.tool_versions.chess4d` is now populated. The distribution
+  name is `python-chess4d-oana-chiru`, not `chess4d`, so the previous
+  `importlib.metadata.version("chess4d")` call raised
+  `PackageNotFoundError` and silently dropped the field.
+
+## [0.1.1] — prior release
+
+- Startpos pawn-axis fix: pawns on the `y ∈ {1, 6}` ranks now alternate
+  Y-/W-orientation with `x` per paper §3.3.
+
+## [0.1.0] — prior release
+
+- Initial tagged release: engine core, legality, notation, spectral
+  encoder integration (Phase 8), CLI skeleton.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-chess4d-oana-chiru"
-version = "0.1.1"
+version = "0.2.0"
 description = "Python reference implementation of Oana & Chiru (2026) — A Mathematical Framework for Four-Dimensional Chess (DOI 10.3390/appliedmath6030048)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/chess4d/corpus.py
+++ b/src/chess4d/corpus.py
@@ -1,53 +1,133 @@
 """Random-playout corpus generation (Phase 8).
 
-Produces spectralz v4 files from random legal playouts off the
-Oana-Chiru starting position. Used for downstream empirical work —
-measuring F_D fingerprints, verifying spectral predictions against
-engine data, building tiny training sets.
+Produces a corpus directory that mirrors the ``chess-maths-the-movie``
+layout, so chess4d corpora drop into the same tooling as the 2D chess
+spectral viewer. Each run lands under a dated ``run_id`` subdirectory::
+
+    <output>/<run_id>/
+      manifest.json                    # run metadata + per-game rows
+      c4d/game_NNN.c4d                 # compact 4D move notation
+      ndjson/game_NNN.ndjson           # per-ply pos4 snapshots + moves
+      spectralz/game_NNN.spectralz     # 45 056-dim per-ply encoding
+
+The ``spectralz/`` directory is absent with ``--no-encode`` and holds
+tail-only frames under ``--encode-last N`` (frames carry absolute ply
+numbers so they line up with the NDJSON and sidecar c4d).
 
 Entry points::
 
-    chess4d.corpus.generate_corpus(n_games=N, seed=S, ...) -> list[Path]
+    chess4d.corpus.generate_corpus(n_games=N, seed=S, ...) -> CorpusResult
 
 and, via ``[project.scripts]``::
 
     chess4d-corpus-gen --n-games 10 --seed 42 --output ./corpus
+    chess4d-corpus-gen --n-games 1 --max-plies 500 --encode-last 30
+    chess4d-corpus-gen --n-games 1 --max-plies 500 --no-encode
+    chess4d-corpus-gen --n-games 1 --run-id fixed-corpus-v1
 
 The CLI also runs via ``python -m chess4d.corpus``. Termination
 reasons ("checkmate" / "stalemate" / "max_plies") are logged to stderr
-and returned in the per-game summary so the caller can tally them.
+and carried on each :class:`GameSummary` so the caller can tally them.
+
+Schema docs
+-----------
+* NDJSON schema id: ``"chess4d-ndjson-v1"`` on line 1.
+* Manifest top-level keys: ``generated_utc``, ``run_id``, ``source``,
+  ``fetch_params``, ``tool_versions``, ``aggregates``, ``games``.
+* Per-ply pos4 dict uses the v1.1.1 Oana-Chiru schema — 2-char pawn
+  values (``Pw``/``Py``/``pw``/``py``) and 1-char non-pawns.
+
+The ``[spectral]`` extra is only required when encoding is enabled;
+``chess_spectral`` is imported lazily inside ``_encode_one_game`` so
+``--no-encode`` runs on a bare install.
 """
 
 from __future__ import annotations
 
 import argparse
+import copy
+import json
 import random
 import sys
+import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
-from chess4d.spectral import write_spectralz
+from chess4d.notation import write_game_file
 from chess4d.startpos import initial_position
-from chess4d.types import Move4D
+from chess4d.state import GameState
+from chess4d.types import Color, Move4D, PawnAxis, PieceType, Square4D
 
 
-__all__ = ["GameSummary", "generate_corpus", "main", "play_random_game"]
+__all__ = [
+    "CorpusResult",
+    "GameSummary",
+    "generate_corpus",
+    "main",
+    "play_random_game",
+    "write_ndjson_game",
+]
+
+
+NDJSON_FORMAT_ID = "chess4d-ndjson-v1"
 
 
 @dataclass(frozen=True)
 class GameSummary:
     """One row of per-game stats from :func:`generate_corpus`.
 
-    ``termination`` is one of ``"checkmate"``, ``"stalemate"``, or
-    ``"max_plies"``. ``bytes_written`` is the spectralz file size
-    reported by :func:`write_spectralz`.
+    * ``stem`` — filename stem shared by the c4d / ndjson / spectralz
+      artifacts (e.g. ``"game_001"``).
+    * ``c4d_path`` — path to the compact 4D move log (always present).
+    * ``ndjson_path`` — path to the NDJSON per-ply record stream
+      (always present).
+    * ``encoding_path`` — path to the spectralz file, or ``None`` when
+      encoding was skipped via ``encode=False``.
+    * ``plies`` — total plies played (length of the c4d/NDJSON move list).
+    * ``encoded_plies`` — plies carried in the spectralz file; equal
+      to ``plies`` by default, ``min(plies, encode_last)`` when a tail
+      is requested, and ``0`` when encoding was skipped.
+    * ``pivot_ply`` — absolute ply of the first encoded frame, i.e.
+      ``max(0, plies - encode_last)``. Zero when encoding the full game
+      or when encoding was skipped.
+    * ``termination`` — one of ``"checkmate"``, ``"stalemate"``,
+      ``"max_plies"``.
+    * ``c4d_bytes`` / ``ndjson_bytes`` / ``encoding_bytes`` — on-disk
+      sizes; ``encoding_bytes`` is ``0`` when encoding was skipped.
     """
 
-    path: Path
+    stem: str
+    c4d_path: Path
+    ndjson_path: Path
+    encoding_path: Optional[Path]
     plies: int
+    encoded_plies: int
+    pivot_ply: int
     termination: str
-    bytes_written: int
+    c4d_bytes: int
+    ndjson_bytes: int
+    encoding_bytes: int
+
+
+@dataclass(frozen=True)
+class CorpusResult:
+    """Top-level return value of :func:`generate_corpus`.
+
+    * ``run_dir`` — the ``<output>/<run_id>/`` directory holding all
+      artifacts for this run.
+    * ``run_id`` — the subdirectory basename (either caller-provided or
+      auto-generated via :func:`_auto_run_id`).
+    * ``manifest_path`` — path to the run's ``manifest.json``.
+    * ``games`` — one :class:`GameSummary` per generated game, in the
+      order they were played.
+    """
+
+    run_dir: Path
+    run_id: str
+    manifest_path: Path
+    games: list[GameSummary]
 
 
 def play_random_game(
@@ -72,50 +152,435 @@ def play_random_game(
     return moves, "max_plies"
 
 
+def _state_after(moves: list[Move4D]) -> GameState:
+    """Replay ``moves`` from the starting position and return the final state.
+
+    Used to obtain a mid-game snapshot for tail-encoded spectralz
+    output without invoking the encoder on the prefix plies.
+    """
+    gs = initial_position()
+    for m in moves:
+        gs.push(m)
+    return gs
+
+
+# --- pos4 / NDJSON ----------------------------------------------------------
+
+
+_NONPAWN_CHAR: dict[PieceType, str] = {
+    PieceType.KNIGHT: "N",
+    PieceType.BISHOP: "B",
+    PieceType.ROOK: "R",
+    PieceType.QUEEN: "Q",
+    PieceType.KING: "K",
+}
+
+
+def _linear_index(sq: Square4D) -> int:
+    """Encoder's linear square index: ``(x<<9) | (y<<6) | (z<<3) | w``.
+
+    Matches :func:`chess4d.spectral._linear_index` bit-for-bit so the
+    NDJSON pos4 dict and the spectralz channel layout share one
+    addressing scheme.
+    """
+    return (sq.x << 9) | (sq.y << 6) | (sq.z << 3) | sq.w
+
+
+def _pos4_compact(gs: GameState) -> dict[str, str]:
+    """Serialize the occupied board into a JSON-safe pos4 dict.
+
+    Keys are the linear square index (``str(int)``), values follow the
+    v1.1.1 Oana-Chiru schema:
+
+    * Pawns are two characters — ``P``/``p`` (white/black) followed by
+      ``y``/``w`` (forward axis).
+    * Non-pawns are one character — ``K``/``Q``/``R``/``B``/``N``
+      uppercase for White and lowercase for Black.
+
+    Empty squares are omitted, matching the 4D "FEN-equivalent" format
+    described in the ``chess_spectral_4d_notebook`` spec. JSON object
+    keys must be strings, so the integer linear index is emitted as a
+    decimal string; re-indexing on the reader side is a single
+    ``int(k)``.
+    """
+    pos4: dict[str, str] = {}
+    for color in (Color.WHITE, Color.BLACK):
+        uppercase = color is Color.WHITE
+        for sq, piece in gs.board.pieces_of(color):
+            key = str(_linear_index(sq))
+            if piece.piece_type is PieceType.PAWN:
+                axis = piece.pawn_axis
+                if axis is None:  # pragma: no cover — Piece invariant
+                    raise ValueError(
+                        f"Pawn at {sq} has no pawn_axis; cannot encode."
+                    )
+                color_char = "P" if uppercase else "p"
+                axis_char = "y" if axis is PawnAxis.Y else "w"
+                pos4[key] = f"{color_char}{axis_char}"
+                continue
+            base = _NONPAWN_CHAR.get(piece.piece_type)
+            if base is None:  # pragma: no cover — PieceType closed set
+                raise ValueError(
+                    f"Unrecognized piece_type {piece.piece_type!r} at {sq}."
+                )
+            pos4[key] = base if uppercase else base.lower()
+    return pos4
+
+
+def _move_record(
+    move: Optional[Move4D],
+) -> dict[str, Any]:
+    """Fields describing the move that produced this position.
+
+    The ply-0 record carries ``move_from = move_to = None`` and
+    ``is_castling = is_en_passant = False``; subsequent records carry
+    the 4-tuple coordinates and the promotion piece-type name (or
+    ``None`` if not a promotion).
+    """
+    if move is None:
+        return {
+            "move_from": None,
+            "move_to": None,
+            "move_promo": None,
+            "is_castling": False,
+            "is_en_passant": False,
+        }
+    return {
+        "move_from": [move.from_sq.x, move.from_sq.y, move.from_sq.z, move.from_sq.w],
+        "move_to": [move.to_sq.x, move.to_sq.y, move.to_sq.z, move.to_sq.w],
+        "move_promo": move.promotion.name if move.promotion is not None else None,
+        "is_castling": bool(move.is_castling),
+        "is_en_passant": bool(move.is_en_passant),
+    }
+
+
+def write_ndjson_game(
+    path: Path,
+    start: GameState,
+    moves: list[Move4D],
+    *,
+    termination: str,
+    game_index: int,
+    seed: Optional[int],
+) -> int:
+    """Write one game as NDJSON; return bytes written.
+
+    File shape::
+
+        line 1   format header          {"format":"chess4d-ndjson-v1"}
+        line 2   game header            {"type":"game_header", ...}
+        line 3+  per-ply record         one per position (ply 0 .. n_plies)
+
+    The initial position is included as ply 0 with no move fields, so
+    an N-move game yields N+2 lines total (header + game header + N+1
+    records). ``side_to_move`` is the color that moves *next* from this
+    position — flipped each ply by :meth:`GameState.push`.
+    """
+    current = copy.deepcopy(start)
+    lines: list[str] = []
+    lines.append(json.dumps({"format": NDJSON_FORMAT_ID}, sort_keys=True))
+    headers: dict[str, Any] = {
+        "termination": termination,
+        "n_plies": len(moves),
+    }
+    if seed is not None:
+        headers["seed"] = seed
+    lines.append(
+        json.dumps(
+            {"type": "game_header", "game": game_index, "headers": headers},
+            sort_keys=True,
+        )
+    )
+    # Ply 0 — initial position, no move.
+    record_0: dict[str, Any] = {
+        "game": game_index,
+        "ply": 0,
+        **_move_record(None),
+        "side_to_move": current.side_to_move.name,
+        "pos4": _pos4_compact(current),
+    }
+    lines.append(json.dumps(record_0, sort_keys=True))
+    for ply, move in enumerate(moves, start=1):
+        current.push(move)
+        record: dict[str, Any] = {
+            "game": game_index,
+            "ply": ply,
+            **_move_record(move),
+            "side_to_move": current.side_to_move.name,
+            "pos4": _pos4_compact(current),
+        }
+        lines.append(json.dumps(record, sort_keys=True))
+    text = "\n".join(lines) + "\n"
+    path.write_text(text, encoding="utf-8")
+    # Report the on-disk size (which may differ from ``len(text)`` on
+    # Windows when newline translation rewrites ``\n`` to ``\r\n``).
+    return path.stat().st_size
+
+
+# --- run id / manifest ------------------------------------------------------
+
+
+def _auto_run_id(seed: Optional[int], *, now: Optional[datetime] = None) -> str:
+    """Mint a default ``run_id`` from the UTC clock and seed.
+
+    Format: ``corpus_YYYYMMDD_HHMMSS_seedNNN`` (or ``..._unseeded`` when
+    no seed was supplied). ``now`` is an injection seam for tests — it
+    defaults to ``datetime.now(timezone.utc)``.
+    """
+    stamp = (now or datetime.now(timezone.utc)).strftime("%Y%m%d_%H%M%S")
+    tail = f"seed{seed}" if seed is not None else "unseeded"
+    return f"corpus_{stamp}_{tail}"
+
+
+def _tool_versions() -> dict[str, str]:
+    """Best-effort ``tool_versions`` block for the manifest.
+
+    Always reports ``python``. Tries :mod:`importlib.metadata` for
+    ``chess4d`` and ``chess_spectral``; missing packages (e.g. source
+    checkout without an installed wheel, or ``chess_spectral`` absent
+    because the extra wasn't installed) are silently skipped rather
+    than failing the run.
+    """
+    from importlib.metadata import PackageNotFoundError, version
+
+    versions: dict[str, str] = {
+        "python": f"{sys.version_info.major}.{sys.version_info.minor}."
+        f"{sys.version_info.micro}",
+    }
+    for pkg in ("chess4d", "chess_spectral"):
+        try:
+            versions[pkg] = version(pkg)
+        except PackageNotFoundError:
+            continue
+    return versions
+
+
+def _write_manifest(
+    run_dir: Path,
+    *,
+    run_id: str,
+    fetch_params: dict[str, Any],
+    aggregates: dict[str, Any],
+    games: list[GameSummary],
+) -> Path:
+    """Serialize ``manifest.json`` for one corpus run; return the path.
+
+    The ``games`` list maps :class:`GameSummary` into the compact
+    schema in the plan: per-game rows carry relative paths (so the
+    run directory is relocatable), byte sizes, and the pivot ply for
+    tail-encoded spectralz. ``spectralz`` / ``spectralz_bytes`` are
+    ``None`` when encoding was skipped.
+    """
+    games_block: list[dict[str, Any]] = []
+    for i, g in enumerate(games, start=1):
+        games_block.append(
+            {
+                "index": i,
+                "stem": g.stem,
+                "c4d": f"c4d/{g.c4d_path.name}",
+                "ndjson": f"ndjson/{g.ndjson_path.name}",
+                "spectralz": (
+                    f"spectralz/{g.encoding_path.name}"
+                    if g.encoding_path is not None
+                    else None
+                ),
+                "c4d_bytes": g.c4d_bytes,
+                "ndjson_bytes": g.ndjson_bytes,
+                "spectralz_bytes": (
+                    g.encoding_bytes if g.encoding_path is not None else None
+                ),
+                "plies": g.plies,
+                "encoded_plies": g.encoded_plies,
+                "pivot_ply": g.pivot_ply,
+                "termination": g.termination,
+            }
+        )
+    manifest: dict[str, Any] = {
+        "generated_utc": datetime.now(timezone.utc).isoformat(),
+        "run_id": run_id,
+        "source": "random_playout",
+        "fetch_params": fetch_params,
+        "tool_versions": _tool_versions(),
+        "aggregates": aggregates,
+        "games": games_block,
+    }
+    path = run_dir / "manifest.json"
+    path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+# --- encoding dispatch ------------------------------------------------------
+
+
+def _encode_one_game(
+    moves: list[Move4D],
+    path: Path,
+    *,
+    encode_last: Optional[int],
+) -> tuple[int, int, int]:
+    """Write the spectralz file for one game. Returns ``(pivot, encoded_plies, nbytes)``.
+
+    ``pivot`` is the absolute ply index of the first encoded frame
+    (``0`` when encoding the whole game). ``encoded_plies`` counts the
+    moves carried in the file (``len(moves) - pivot``); the frame
+    count on disk is one greater because of the leading
+    initial-state sentinel. Lazily imports :mod:`chess4d.spectral` so
+    callers on the ``--no-encode`` path never touch ``chess_spectral``.
+    """
+    from chess4d.spectral import write_spectralz  # lazy import
+
+    total = len(moves)
+    pivot = max(0, total - encode_last) if encode_last is not None else 0
+    start = _state_after(moves[:pivot])
+    tail_moves = moves[pivot:]
+    nbytes = write_spectralz(path, start, tail_moves, base_ply=pivot)
+    return pivot, len(tail_moves), nbytes
+
+
+# --- corpus entry point -----------------------------------------------------
+
+
 def generate_corpus(
     n_games: int,
     *,
     max_plies: int = 200,
     seed: Optional[int] = None,
     output_dir: str | Path = "./corpus",
-) -> list[GameSummary]:
-    """Generate ``n_games`` random-playout spectralz v4 files.
+    encode: bool = True,
+    encode_last: Optional[int] = None,
+    run_id: Optional[str] = None,
+) -> CorpusResult:
+    """Generate ``n_games`` random-playout games under a new run directory.
 
-    ``seed`` fully determines the output: two calls with the same
-    ``(n_games, max_plies, seed)`` write byte-identical files. Files
-    are named ``game_001.spectralz`` through ``game_{n_games:03d}
-    .spectralz``; the output directory is created if absent.
+    Layout mirrors ``chess-maths-the-movie``: ``output_dir`` is treated
+    as the parent, and the artifacts land under a freshly-created
+    ``<output_dir>/<run_id>/`` subdirectory. Each game produces a
+    compact ``.c4d`` move log and an NDJSON per-ply record stream;
+    spectralz output is optional and controlled by ``encode`` /
+    ``encode_last``.
+
+    ``encode_last`` restricts the spectralz encoding to the final N
+    plies of each game — the c4d and NDJSON sidecars always carry the
+    full move list. ``encode=False`` and a non-``None`` ``encode_last``
+    together are contradictory and the CLI rejects them up front.
+
+    ``seed`` fully determines the random-playout output: two calls
+    with the same ``(n_games, max_plies, seed)`` produce byte-identical
+    c4d, NDJSON, and spectralz files. When ``run_id`` is ``None`` a
+    fresh one is minted from the UTC clock (see :func:`_auto_run_id`),
+    so back-to-back runs land in distinct directories.
     """
-    out = Path(output_dir)
-    out.mkdir(parents=True, exist_ok=True)
+    if not encode and encode_last is not None:
+        raise ValueError(
+            "encode=False and encode_last are mutually exclusive; "
+            "disable one."
+        )
+    resolved_run_id = run_id if run_id is not None else _auto_run_id(seed)
+    out_root = Path(output_dir)
+    run_dir = out_root / resolved_run_id
+    c4d_dir = run_dir / "c4d"
+    ndjson_dir = run_dir / "ndjson"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    c4d_dir.mkdir(parents=True, exist_ok=True)
+    ndjson_dir.mkdir(parents=True, exist_ok=True)
+    spectralz_dir: Optional[Path] = None
+    if encode:
+        spectralz_dir = run_dir / "spectralz"
+        spectralz_dir.mkdir(parents=True, exist_ok=True)
     rng = random.Random(seed)
     summaries: list[GameSummary] = []
+    wall_start = time.monotonic()
     for i in range(1, n_games + 1):
+        stem = f"game_{i:03d}"
         moves, termination = play_random_game(rng, max_plies)
-        path = out / f"game_{i:03d}.spectralz"
-        start = initial_position()
-        nbytes = write_spectralz(path, start, moves)
+        c4d_path = c4d_dir / f"{stem}.c4d"
+        ndjson_path = ndjson_dir / f"{stem}.ndjson"
+        write_game_file(c4d_path, initial_position(), moves)
+        c4d_bytes = c4d_path.stat().st_size
+        ndjson_bytes = write_ndjson_game(
+            ndjson_path,
+            initial_position(),
+            moves,
+            termination=termination,
+            game_index=i - 1,
+            seed=seed,
+        )
+        encoding_path: Optional[Path] = None
+        encoded_plies = 0
+        encoding_bytes = 0
+        pivot = 0
+        if encode:
+            assert spectralz_dir is not None  # mkdir above
+            encoding_path = spectralz_dir / f"{stem}.spectralz"
+            pivot, encoded_plies, encoding_bytes = _encode_one_game(
+                moves, encoding_path, encode_last=encode_last
+            )
         summaries.append(
             GameSummary(
-                path=path,
+                stem=stem,
+                c4d_path=c4d_path,
+                ndjson_path=ndjson_path,
+                encoding_path=encoding_path,
                 plies=len(moves),
+                encoded_plies=encoded_plies,
+                pivot_ply=pivot,
                 termination=termination,
-                bytes_written=nbytes,
+                c4d_bytes=c4d_bytes,
+                ndjson_bytes=ndjson_bytes,
+                encoding_bytes=encoding_bytes,
             )
         )
+        tail_tag = (
+            f" encoded_plies={encoded_plies:4d} pivot={pivot:4d}"
+            if encode and encode_last is not None
+            else ""
+        )
+        bytes_tag = f" bytes={encoding_bytes}" if encode else " no-encode"
         print(
-            f"game_{i:03d}: plies={len(moves):4d} "
-            f"term={termination:10s} bytes={nbytes}",
+            f"{stem}: plies={len(moves):4d} "
+            f"term={termination:10s}{tail_tag}{bytes_tag}",
             file=sys.stderr,
         )
-    return summaries
+    wall_time_s = time.monotonic() - wall_start
+    fetch_params: dict[str, Any] = {
+        "n_games": n_games,
+        "max_plies": max_plies,
+        "seed": seed,
+        "encode": encode,
+        "encode_last": encode_last,
+    }
+    aggregates: dict[str, Any] = {
+        "n_games": len(summaries),
+        "n_encoded_games": sum(1 for s in summaries if s.encoding_path is not None),
+        "total_plies": sum(s.plies for s in summaries),
+        "total_encoded_plies": sum(s.encoded_plies for s in summaries),
+        "n_errors": 0,
+        "wall_time_s": round(wall_time_s, 3),
+    }
+    manifest_path = _write_manifest(
+        run_dir,
+        run_id=resolved_run_id,
+        fetch_params=fetch_params,
+        aggregates=aggregates,
+        games=summaries,
+    )
+    return CorpusResult(
+        run_dir=run_dir,
+        run_id=resolved_run_id,
+        manifest_path=manifest_path,
+        games=summaries,
+    )
+
+
+# --- CLI --------------------------------------------------------------------
 
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="chess4d-corpus-gen",
-        description="Generate a corpus of spectralz v4 files from random "
-        "Oana-Chiru playouts.",
+        description="Generate a chess4d random-playout corpus under "
+        "<output>/<run_id>/ with manifest.json + c4d/ + ndjson/ + "
+        "spectralz/ (layout mirrors chess-maths-the-movie).",
     )
     parser.add_argument(
         "--n-games", type=int, default=10, help="Number of games to generate."
@@ -136,7 +601,30 @@ def _build_parser() -> argparse.ArgumentParser:
         "--output",
         type=Path,
         default=Path("./corpus"),
-        help="Directory to write game_NNN.spectralz files into.",
+        help="Parent directory; the run lands under <output>/<run_id>/.",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=str,
+        default=None,
+        metavar="ID",
+        help="Override the auto-generated run_id subdirectory name "
+        "(default: corpus_YYYYMMDD_HHMMSS_seedNNN).",
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--encode-last",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Encode only the final N plies into spectralz; the c4d "
+        "and NDJSON sidecars still carry the full move list. Frames "
+        "carry absolute ply numbers.",
+    )
+    group.add_argument(
+        "--no-encode",
+        action="store_true",
+        help="Skip spectralz output entirely; emit only c4d and NDJSON.",
     )
     return parser
 
@@ -145,17 +633,22 @@ def main(argv: Optional[list[str]] = None) -> int:
     """CLI entry point. Returns the process exit code."""
     parser = _build_parser()
     args = parser.parse_args(argv)
-    summaries = generate_corpus(
+    result = generate_corpus(
         n_games=args.n_games,
         max_plies=args.max_plies,
         seed=args.seed,
         output_dir=args.output,
+        encode=not args.no_encode,
+        encode_last=args.encode_last,
+        run_id=args.run_id,
     )
-    total_bytes = sum(s.bytes_written for s in summaries)
-    total_plies = sum(s.plies for s in summaries)
+    total_encoded_bytes = sum(s.encoding_bytes for s in result.games)
+    total_plies = sum(s.plies for s in result.games)
+    total_encoded_plies = sum(s.encoded_plies for s in result.games)
     print(
-        f"wrote {len(summaries)} games, {total_plies} plies, "
-        f"{total_bytes} bytes to {args.output}",
+        f"wrote {len(result.games)} games, {total_plies} plies "
+        f"(encoded {total_encoded_plies}), "
+        f"{total_encoded_bytes} spectralz bytes to {result.run_dir}",
         file=sys.stderr,
     )
     return 0

--- a/src/chess4d/corpus.py
+++ b/src/chess4d/corpus.py
@@ -336,10 +336,14 @@ def _tool_versions() -> dict[str, str]:
     """Best-effort ``tool_versions`` block for the manifest.
 
     Always reports ``python``. Tries :mod:`importlib.metadata` for
-    ``chess4d`` and ``chess_spectral``; missing packages (e.g. source
-    checkout without an installed wheel, or ``chess_spectral`` absent
-    because the extra wasn't installed) are silently skipped rather
-    than failing the run.
+    ``chess4d`` (dist name ``python-chess4d-oana-chiru``) and
+    ``chess_spectral``; missing packages (e.g. source checkout without
+    an installed wheel, or ``chess_spectral`` absent because the extra
+    wasn't installed) are silently skipped rather than failing the run.
+
+    The manifest keys stay short (``chess4d``, ``chess_spectral``)
+    regardless of upstream dist-name renames, so downstream consumers
+    have a stable surface.
     """
     from importlib.metadata import PackageNotFoundError, version
 
@@ -347,9 +351,14 @@ def _tool_versions() -> dict[str, str]:
         "python": f"{sys.version_info.major}.{sys.version_info.minor}."
         f"{sys.version_info.micro}",
     }
-    for pkg in ("chess4d", "chess_spectral"):
+    # (manifest_key, distribution_name)
+    probes = (
+        ("chess4d", "python-chess4d-oana-chiru"),
+        ("chess_spectral", "chess_spectral"),
+    )
+    for key, dist in probes:
         try:
-            versions[pkg] = version(pkg)
+            versions[key] = version(dist)
         except PackageNotFoundError:
             continue
     return versions

--- a/src/chess4d/spectral.py
+++ b/src/chess4d/spectral.py
@@ -183,13 +183,24 @@ def write_spectralz(
     path: str | Path,
     start: GameState,
     moves: Iterable[Move4D],
+    *,
+    base_ply: int = 0,
 ) -> int:
     """Encode a game and write it as a spectralz v4 file. Returns bytes written.
 
-    The first frame is the ply-0 initial state with a zero-move
-    sentinel; subsequent frames carry the applied move's geometry and
-    flags. ``moves`` is consumed eagerly so the writer can report
-    ``n_plies`` in the header before streaming frames.
+    The first frame is the ``start`` state with a zero-move sentinel;
+    subsequent frames carry each applied move's geometry and flags.
+    ``moves`` is consumed eagerly so the writer can report ``n_plies``
+    in the header before streaming frames.
+
+    ``base_ply`` offsets the ``Frame4D.ply`` values written to disk —
+    the default of ``0`` keeps the legacy behavior where the first
+    frame is labeled ply 0. Set ``base_ply`` to the absolute ply index
+    of ``start`` when writing a tail-encoded file (e.g. pass
+    ``base_ply=470`` when ``start`` is the state at absolute ply 470 of
+    a longer game). The sidecar JSON written by
+    :mod:`chess4d.corpus` carries the full move list, so analysis
+    tooling can join the two via absolute ``ply`` numbers.
     """
     move_list = list(moves)
     frames: list[Frame4D] = []
@@ -199,7 +210,7 @@ def write_spectralz(
         frames.append(
             Frame4D(
                 encoding=encoding,
-                ply=ply,
+                ply=base_ply + ply,
                 from_sq=from_c,
                 to_sq=to_c,
                 promo=promo,

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -243,6 +243,24 @@ def test_manifest_has_required_top_level_keys(tmp_path: Path) -> None:
     assert manifest["tool_versions"]["python"].count(".") == 2
 
 
+def test_manifest_tool_versions_includes_chess4d(tmp_path: Path) -> None:
+    """``tool_versions.chess4d`` is populated from the installed wheel.
+
+    Regression guard: the dist name is ``python-chess4d-oana-chiru``,
+    not ``chess4d``, so a naive ``version("chess4d")`` call raises
+    ``PackageNotFoundError`` and silently drops the field. The manifest
+    must look up the correct dist but keep the short key stable for
+    downstream consumers.
+    """
+    result = generate_corpus(
+        n_games=1, max_plies=4, seed=0, output_dir=tmp_path, encode=False
+    )
+    manifest = _read_manifest(result.run_dir)
+    assert "chess4d" in manifest["tool_versions"]
+    # Looks like a dotted semver (e.g. "0.2.0" or "0.2.0.dev3").
+    assert manifest["tool_versions"]["chess4d"].count(".") >= 2
+
+
 def test_manifest_games_block_matches_summaries_no_encode(tmp_path: Path) -> None:
     result = generate_corpus(
         n_games=2, max_plies=6, seed=0, output_dir=tmp_path, encode=False

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1,0 +1,481 @@
+"""Corpus generator — chess-maths-the-movie nested layout.
+
+Each run lands in ``<output>/<run_id>/`` with four artifact kinds:
+
+* ``manifest.json`` — run metadata + per-game rows.
+* ``c4d/game_NNN.c4d`` — compact 4D move notation (always present).
+* ``ndjson/game_NNN.ndjson`` — per-ply pos4 snapshots + moves
+  (always present).
+* ``spectralz/game_NNN.spectralz`` — 45 056-dim per-ply encoding
+  (absent with ``--no-encode``; tail-only with ``--encode-last``).
+
+The spectralz-writing branch needs ``chess_spectral``, so encoding
+tests skip at module import when the extra is missing. The NDJSON /
+manifest / ``--no-encode`` assertions run on a bare install via the
+dedicated ``NoEncode`` suite at the bottom of the file.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from chess4d.corpus import (
+    NDJSON_FORMAT_ID,
+    CorpusResult,
+    GameSummary,
+    _auto_run_id,
+    generate_corpus,
+    main,
+)
+from chess4d.notation import read_game_file
+
+
+# --- Helpers shared by encode / no-encode suites ---------------------------
+
+
+def _read_ndjson_lines(path: Path) -> list[dict]:
+    """Parse one NDJSON file into a list of records (preserves order)."""
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def _read_manifest(run_dir: Path) -> dict:
+    """Load ``run_dir/manifest.json`` into a plain dict."""
+    return json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+
+
+# --- No-encode mode: runs without chess_spectral --------------------------
+
+
+# These tests exercise the c4d / NDJSON / manifest paths only and do
+# not need the spectral extra. They share tmp_path semantics with the
+# encoded suite below.
+
+
+def test_generate_corpus_creates_run_dir_without_encode(tmp_path: Path) -> None:
+    result = generate_corpus(
+        n_games=2,
+        max_plies=8,
+        seed=0,
+        output_dir=tmp_path,
+        encode=False,
+    )
+    assert isinstance(result, CorpusResult)
+    assert result.run_dir.parent == tmp_path
+    assert result.run_dir.is_dir()
+    assert (result.run_dir / "c4d").is_dir()
+    assert (result.run_dir / "ndjson").is_dir()
+    assert not (result.run_dir / "spectralz").exists()
+    assert result.manifest_path.exists()
+
+
+def test_no_encode_game_summaries(tmp_path: Path) -> None:
+    result = generate_corpus(
+        n_games=2,
+        max_plies=8,
+        seed=0,
+        output_dir=tmp_path,
+        encode=False,
+    )
+    for s in result.games:
+        assert isinstance(s, GameSummary)
+        assert s.c4d_path.exists()
+        assert s.ndjson_path.exists()
+        assert s.encoding_path is None
+        assert s.encoded_plies == 0
+        assert s.pivot_ply == 0
+        assert s.encoding_bytes == 0
+        assert s.c4d_bytes > 0
+        assert s.ndjson_bytes > 0
+
+
+def test_c4d_roundtrips(tmp_path: Path) -> None:
+    """c4d sidecar parses back to the same move list the generator produced."""
+    result = generate_corpus(
+        n_games=1, max_plies=8, seed=0, output_dir=tmp_path, encode=False
+    )
+    (s,) = result.games
+    _, moves = read_game_file(s.c4d_path)
+    assert len(moves) == s.plies
+
+
+def test_encode_false_with_encode_last_raises(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        generate_corpus(
+            n_games=1,
+            max_plies=4,
+            seed=0,
+            output_dir=tmp_path,
+            encode=False,
+            encode_last=2,
+        )
+
+
+def test_run_id_override(tmp_path: Path) -> None:
+    result = generate_corpus(
+        n_games=1,
+        max_plies=4,
+        seed=0,
+        output_dir=tmp_path,
+        encode=False,
+        run_id="my-fixed-corpus",
+    )
+    assert result.run_id == "my-fixed-corpus"
+    assert result.run_dir == tmp_path / "my-fixed-corpus"
+    assert result.run_dir.is_dir()
+
+
+def test_auto_run_id_has_stable_format() -> None:
+    fixed_now = datetime(2026, 4, 19, 18, 3, 42, tzinfo=timezone.utc)
+    assert _auto_run_id(42, now=fixed_now) == "corpus_20260419_180342_seed42"
+    assert _auto_run_id(None, now=fixed_now) == "corpus_20260419_180342_unseeded"
+
+
+def test_auto_run_id_used_by_default(tmp_path: Path) -> None:
+    result = generate_corpus(
+        n_games=1, max_plies=4, seed=7, output_dir=tmp_path, encode=False
+    )
+    assert result.run_id.startswith("corpus_")
+    assert result.run_id.endswith("_seed7")
+    # The run_dir's basename matches the returned run_id verbatim.
+    assert result.run_dir.name == result.run_id
+
+
+def test_ndjson_schema_headers_and_records(tmp_path: Path) -> None:
+    """Line 1 is the format tag; line 2 is the game header; the rest
+    are per-ply records whose count matches ``plies + 1``."""
+    result = generate_corpus(
+        n_games=1, max_plies=10, seed=0, output_dir=tmp_path, encode=False
+    )
+    (s,) = result.games
+    records = _read_ndjson_lines(s.ndjson_path)
+    assert records[0] == {"format": NDJSON_FORMAT_ID}
+    game_header = records[1]
+    assert game_header["type"] == "game_header"
+    assert game_header["game"] == 0
+    assert game_header["headers"]["n_plies"] == s.plies
+    assert game_header["headers"]["seed"] == 0
+    assert game_header["headers"]["termination"] == s.termination
+    # One per-ply record per position (plies + 1, including ply 0).
+    ply_records = records[2:]
+    assert len(ply_records) == s.plies + 1
+    # Plies are consecutive starting from 0.
+    assert [r["ply"] for r in ply_records] == list(range(s.plies + 1))
+
+
+def test_ndjson_ply0_has_no_move_fields(tmp_path: Path) -> None:
+    result = generate_corpus(
+        n_games=1, max_plies=4, seed=0, output_dir=tmp_path, encode=False
+    )
+    (s,) = result.games
+    records = _read_ndjson_lines(s.ndjson_path)
+    ply0 = records[2]
+    assert ply0["ply"] == 0
+    assert ply0["move_from"] is None
+    assert ply0["move_to"] is None
+    assert ply0["move_promo"] is None
+    assert ply0["is_castling"] is False
+    assert ply0["is_en_passant"] is False
+    # Side to move at ply 0 is White.
+    assert ply0["side_to_move"] == "WHITE"
+
+
+def test_ndjson_pos4_initial_counts(tmp_path: Path) -> None:
+    """The starting-position pos4 dict has 896 entries — 2-char pawn
+    values and 1-char non-pawns, split 448/448 per the paper."""
+    result = generate_corpus(
+        n_games=1, max_plies=2, seed=0, output_dir=tmp_path, encode=False
+    )
+    (s,) = result.games
+    records = _read_ndjson_lines(s.ndjson_path)
+    pos4_ply0 = records[2]["pos4"]
+    assert len(pos4_ply0) == 896
+    pawns = [v for v in pos4_ply0.values() if len(v) == 2]
+    nonpawns = [v for v in pos4_ply0.values() if len(v) == 1]
+    assert len(pawns) == 448
+    assert len(nonpawns) == 448
+    # Pawn values are color+axis: P/p prefix, y/w suffix.
+    for v in pawns:
+        assert v[0] in ("P", "p")
+        assert v[1] in ("y", "w")
+    # Non-pawn chars are the Oana-Chiru set, uppercase == white.
+    for v in nonpawns:
+        assert v in ("K", "Q", "R", "B", "N", "k", "q", "r", "b", "n")
+
+
+def test_ndjson_side_to_move_flips_each_ply(tmp_path: Path) -> None:
+    result = generate_corpus(
+        n_games=1, max_plies=6, seed=0, output_dir=tmp_path, encode=False
+    )
+    (s,) = result.games
+    records = _read_ndjson_lines(s.ndjson_path)
+    stm = [r["side_to_move"] for r in records[2:]]
+    # Ply 0 → White to move; after each push, it flips.
+    expected = ["WHITE" if i % 2 == 0 else "BLACK" for i in range(len(stm))]
+    assert stm == expected
+
+
+def test_manifest_has_required_top_level_keys(tmp_path: Path) -> None:
+    result = generate_corpus(
+        n_games=2, max_plies=6, seed=0, output_dir=tmp_path, encode=False
+    )
+    manifest = _read_manifest(result.run_dir)
+    for key in (
+        "generated_utc",
+        "run_id",
+        "source",
+        "fetch_params",
+        "tool_versions",
+        "aggregates",
+        "games",
+    ):
+        assert key in manifest, f"missing manifest key: {key}"
+    assert manifest["source"] == "random_playout"
+    assert manifest["run_id"] == result.run_id
+    assert manifest["fetch_params"]["seed"] == 0
+    assert manifest["fetch_params"]["encode"] is False
+    assert manifest["fetch_params"]["encode_last"] is None
+    assert manifest["aggregates"]["n_games"] == 2
+    assert manifest["aggregates"]["n_encoded_games"] == 0
+    assert manifest["tool_versions"]["python"].count(".") == 2
+
+
+def test_manifest_games_block_matches_summaries_no_encode(tmp_path: Path) -> None:
+    result = generate_corpus(
+        n_games=2, max_plies=6, seed=0, output_dir=tmp_path, encode=False
+    )
+    manifest = _read_manifest(result.run_dir)
+    rows = manifest["games"]
+    assert len(rows) == len(result.games)
+    for row, summary in zip(rows, result.games):
+        assert row["stem"] == summary.stem
+        assert row["c4d"] == f"c4d/{summary.stem}.c4d"
+        assert row["ndjson"] == f"ndjson/{summary.stem}.ndjson"
+        assert row["spectralz"] is None
+        assert row["spectralz_bytes"] is None
+        assert row["plies"] == summary.plies
+        assert row["encoded_plies"] == 0
+        assert row["pivot_ply"] == 0
+        assert row["termination"] == summary.termination
+
+
+def test_reported_byte_counts_match_on_disk_sizes(tmp_path: Path) -> None:
+    """Manifest + GameSummary byte counts match ``Path.stat().st_size``.
+
+    Regression guard: on Windows, ``Path.write_text`` translates
+    ``\\n`` to ``\\r\\n``, so ``len(text.encode("utf-8"))`` is *not*
+    the on-disk size. Corpus writers must return ``stat().st_size``.
+    """
+    result = generate_corpus(
+        n_games=2, max_plies=8, seed=0, output_dir=tmp_path, encode=False
+    )
+    manifest = _read_manifest(result.run_dir)
+    for row, summary in zip(manifest["games"], result.games):
+        assert summary.c4d_bytes == summary.c4d_path.stat().st_size
+        assert summary.ndjson_bytes == summary.ndjson_path.stat().st_size
+        assert row["c4d_bytes"] == summary.c4d_path.stat().st_size
+        assert row["ndjson_bytes"] == summary.ndjson_path.stat().st_size
+
+
+def test_cli_no_encode(tmp_path: Path) -> None:
+    rc = main(
+        [
+            "--n-games", "1",
+            "--seed", "0",
+            "--max-plies", "8",
+            "--no-encode",
+            "--output", str(tmp_path),
+            "--run-id", "cli-no-encode",
+        ]
+    )
+    assert rc == 0
+    run_dir = tmp_path / "cli-no-encode"
+    assert (run_dir / "manifest.json").exists()
+    assert (run_dir / "c4d" / "game_001.c4d").exists()
+    assert (run_dir / "ndjson" / "game_001.ndjson").exists()
+    assert not (run_dir / "spectralz").exists()
+
+
+def test_cli_no_encode_and_encode_last_are_mutually_exclusive(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(SystemExit):
+        main(
+            [
+                "--n-games", "1",
+                "--seed", "0",
+                "--max-plies", "8",
+                "--no-encode",
+                "--encode-last", "3",
+                "--output", str(tmp_path),
+            ]
+        )
+
+
+def test_game_summary_is_frozen(tmp_path: Path) -> None:
+    """GameSummary remains a frozen dataclass (callers rely on immutability)."""
+    result = generate_corpus(
+        n_games=1, max_plies=4, seed=0, output_dir=tmp_path, encode=False
+    )
+    (s,) = result.games
+    with pytest.raises(Exception):  # FrozenInstanceError or dataclasses.FrozenInstanceError
+        s.plies = 999  # type: ignore[misc]
+
+
+def test_corpus_result_is_frozen(tmp_path: Path) -> None:
+    result = generate_corpus(
+        n_games=1, max_plies=4, seed=0, output_dir=tmp_path, encode=False
+    )
+    with pytest.raises(Exception):
+        result.run_id = "other"  # type: ignore[misc]
+
+
+# --- Encoded-mode suite (requires chess_spectral) -------------------------
+
+
+spectral = pytest.importorskip("chess_spectral")
+
+from chess_spectral.frame_4d import read_spectralz_v4  # noqa: E402
+
+
+def test_generate_corpus_writes_all_four_artifacts(tmp_path: Path) -> None:
+    result = generate_corpus(
+        n_games=2, max_plies=8, seed=0, output_dir=tmp_path
+    )
+    assert (result.run_dir / "spectralz").is_dir()
+    for s in result.games:
+        assert s.c4d_path.exists()
+        assert s.ndjson_path.exists()
+        assert s.encoding_path is not None
+        assert s.encoding_path.exists()
+        assert s.encoded_plies == s.plies
+        assert s.pivot_ply == 0
+        assert s.encoding_bytes > 0
+
+
+def test_encode_last_tail_only(tmp_path: Path) -> None:
+    """Tail encoding: spectralz carries the last N plies; c4d/NDJSON carry all."""
+    # Use a seed/max_plies combo that reliably produces a full 20-ply game.
+    result = generate_corpus(
+        n_games=1,
+        max_plies=20,
+        seed=0,
+        output_dir=tmp_path,
+        encode_last=6,
+    )
+    (s,) = result.games
+    assert s.plies == 20
+    assert s.encoded_plies == 6
+    assert s.pivot_ply == 14
+    assert s.encoding_path is not None
+
+    # c4d holds the full 20-move game.
+    _, moves = read_game_file(s.c4d_path)
+    assert len(moves) == 20
+
+    # NDJSON also carries all 20 plies + ply 0.
+    ndjson_records = _read_ndjson_lines(s.ndjson_path)
+    assert len(ndjson_records) == 2 + 20 + 1  # format + game_header + 21 positions
+
+    # Spectralz holds encoded_plies + 1 frames (sentinel + one per move).
+    _, frames = read_spectralz_v4(s.encoding_path)
+    assert len(frames) == s.encoded_plies + 1
+
+
+def test_encode_last_absolute_ply_numbering(tmp_path: Path) -> None:
+    """Tail frames carry absolute ply numbers that line up with c4d/NDJSON."""
+    result = generate_corpus(
+        n_games=1,
+        max_plies=20,
+        seed=0,
+        output_dir=tmp_path,
+        encode_last=6,
+    )
+    (s,) = result.games
+    assert s.encoding_path is not None
+    _, frames = read_spectralz_v4(s.encoding_path)
+    pivot = s.pivot_ply
+    assert [f.ply for f in frames] == list(range(pivot, pivot + s.encoded_plies + 1))
+
+
+def test_encode_last_larger_than_game_encodes_all(tmp_path: Path) -> None:
+    """Requesting a tail longer than the game encodes the whole thing."""
+    result = generate_corpus(
+        n_games=1,
+        max_plies=8,
+        seed=0,
+        output_dir=tmp_path,
+        encode_last=500,
+    )
+    (s,) = result.games
+    assert s.encoded_plies == s.plies
+    assert s.pivot_ply == 0
+    assert s.encoding_path is not None
+    _, frames = read_spectralz_v4(s.encoding_path)
+    # First frame is the true starting position, so ply numbering begins at 0.
+    assert frames[0].ply == 0
+    assert len(frames) == s.plies + 1
+
+
+def test_manifest_with_encoding(tmp_path: Path) -> None:
+    result = generate_corpus(
+        n_games=2,
+        max_plies=20,
+        seed=0,
+        output_dir=tmp_path,
+        encode_last=5,
+    )
+    manifest = _read_manifest(result.run_dir)
+    assert manifest["fetch_params"]["encode"] is True
+    assert manifest["fetch_params"]["encode_last"] == 5
+    assert manifest["aggregates"]["n_encoded_games"] == 2
+    for row, summary in zip(manifest["games"], result.games):
+        assert row["spectralz"] == f"spectralz/{summary.stem}.spectralz"
+        assert row["spectralz_bytes"] == summary.encoding_bytes
+        assert row["encoded_plies"] == summary.encoded_plies
+        assert row["pivot_ply"] == summary.pivot_ply
+
+
+def test_cli_encode_last(tmp_path: Path) -> None:
+    rc = main(
+        [
+            "--n-games", "1",
+            "--seed", "0",
+            "--max-plies", "20",
+            "--encode-last", "5",
+            "--output", str(tmp_path),
+            "--run-id", "cli-encode-last",
+        ]
+    )
+    assert rc == 0
+    run_dir = tmp_path / "cli-encode-last"
+    assert (run_dir / "manifest.json").exists()
+    assert (run_dir / "c4d" / "game_001.c4d").exists()
+    assert (run_dir / "ndjson" / "game_001.ndjson").exists()
+    assert (run_dir / "spectralz" / "game_001.spectralz").exists()
+    _, frames = read_spectralz_v4(run_dir / "spectralz" / "game_001.spectralz")
+    assert len(frames) == 5 + 1  # encoded_plies + sentinel
+
+
+def test_reproducible_under_fixed_seed(tmp_path: Path) -> None:
+    """Same (n_games, max_plies, seed) → byte-identical c4d, NDJSON,
+    and spectralz. ``run_id`` is overridden to isolate manifest drift
+    (``generated_utc`` differs between runs by design)."""
+    a_dir = tmp_path / "a"
+    b_dir = tmp_path / "b"
+    ra = generate_corpus(
+        n_games=2, max_plies=12, seed=42, output_dir=a_dir, run_id="fixed"
+    )
+    rb = generate_corpus(
+        n_games=2, max_plies=12, seed=42, output_dir=b_dir, run_id="fixed"
+    )
+    assert len(ra.games) == len(rb.games) == 2
+    for sa, sb in zip(ra.games, rb.games):
+        assert sa.c4d_path.read_bytes() == sb.c4d_path.read_bytes()
+        assert sa.ndjson_path.read_bytes() == sb.ndjson_path.read_bytes()
+        assert sa.encoding_path is not None
+        assert sb.encoding_path is not None
+        assert sa.encoding_path.read_bytes() == sb.encoding_path.read_bytes()

--- a/tests/test_spectral.py
+++ b/tests/test_spectral.py
@@ -212,27 +212,54 @@ def test_write_spectralz_initial_frame_has_zero_move(tmp_path: Path) -> None:
     assert f0.promo == 0
 
 
+def test_write_spectralz_base_ply_offset(tmp_path: Path) -> None:
+    """``base_ply`` shifts every ``Frame4D.ply`` by a constant offset.
+
+    This is the mechanism corpus.py uses to write tail-encoded files
+    whose ``ply`` numbers match absolute positions in the full game.
+    """
+    start = initial_position()
+    moves = [
+        Move4D(Square4D(0, 1, 3, 3), Square4D(0, 3, 3, 3)),
+        Move4D(Square4D(0, 6, 3, 3), Square4D(0, 4, 3, 3)),
+    ]
+    path = tmp_path / "offset.spectralz"
+    write_spectralz(path, start, moves, base_ply=100)
+    _, frames = read_spectralz_v4(path)
+    assert [f.ply for f in frames] == [100, 101, 102]
+
+
 # 4e. Corpus smoke ----------------------------------------------------------
 
 
 def test_generate_corpus_produces_requested_files(tmp_path: Path) -> None:
-    summaries = generate_corpus(
+    result = generate_corpus(
         n_games=3, max_plies=10, seed=42, output_dir=tmp_path
     )
-    assert len(summaries) == 3
-    for s in summaries:
-        assert s.path.exists()
-        assert s.bytes_written > 0
-        header, _ = read_spectralz_v4(s.path)
+    assert len(result.games) == 3
+    assert (result.run_dir / "spectralz").is_dir()
+    for s in result.games:
+        assert s.c4d_path.exists()
+        assert s.ndjson_path.exists()
+        assert s.encoding_path is not None
+        assert s.encoding_path.exists()
+        assert s.encoding_bytes > 0
+        header, _ = read_spectralz_v4(s.encoding_path)
         assert header.version == 4
 
 
 def test_generate_corpus_is_reproducible_with_seed(tmp_path: Path) -> None:
-    a_dir = tmp_path / "run_a"
-    b_dir = tmp_path / "run_b"
-    generate_corpus(n_games=3, max_plies=10, seed=42, output_dir=a_dir)
-    generate_corpus(n_games=3, max_plies=10, seed=42, output_dir=b_dir)
-    for i in range(1, 4):
-        a = (a_dir / f"game_{i:03d}.spectralz").read_bytes()
-        b = (b_dir / f"game_{i:03d}.spectralz").read_bytes()
-        assert a == b
+    # Fixed run_id so manifest.generated_utc doesn't spuriously differ;
+    # c4d / NDJSON / spectralz are the bytes we actually care about.
+    ra = generate_corpus(
+        n_games=3, max_plies=10, seed=42, output_dir=tmp_path / "a", run_id="fixed"
+    )
+    rb = generate_corpus(
+        n_games=3, max_plies=10, seed=42, output_dir=tmp_path / "b", run_id="fixed"
+    )
+    for sa, sb in zip(ra.games, rb.games):
+        assert sa.encoding_path is not None
+        assert sb.encoding_path is not None
+        assert sa.encoding_path.read_bytes() == sb.encoding_path.read_bytes()
+        assert sa.c4d_path.read_bytes() == sb.c4d_path.read_bytes()
+        assert sa.ndjson_path.read_bytes() == sb.ndjson_path.read_bytes()


### PR DESCRIPTION
Adopts the chess-maths-the-movie directory layout so chess4d corpora drop into the same toolchain as the 2D chess spectral viewer:

    <output>/<run_id>/
      manifest.json
      c4d/game_NNN.c4d
      ndjson/game_NNN.ndjson
      spectralz/game_NNN.spectralz

Supersedes the flat game_NNN.{json,spectralz} layout landed earlier in this branch. Highlights:

* `CorpusResult` / new `GameSummary` fields (stem, c4d/ndjson/encoding paths, plies, encoded_plies, pivot_ply, termination, byte counts)
* NDJSON schema `chess4d-ndjson-v1`: format header + game_header + per-ply records with 4-tuple move_from/move_to, side_to_move, and a full `pos4` snapshot (2-char pawn values Pw/Py/pw/py, 1-char non-pawns, keyed by linear index (x<<9)|(y<<6)|(z<<3)|w)
* `manifest.json` with top-level generated_utc, run_id, source, fetch_params, tool_versions, aggregates, games[]
* Auto run_id `corpus_YYYYMMDD_HHMMSS_seedNNN` (or `..._unseeded`); override via `--run-id`
* Lazy `chess_spectral` import so `--no-encode` runs on a bare install without the `[spectral]` extra
* `write_spectralz(..., base_ply=N)` kwarg for tail-encoded files with absolute ply numbers that join against the full NDJSON
* Regression test guarding manifest byte counts against `Path.stat().st_size` — Windows `write_text` translates \n → \r\n, so `len(text.encode("utf-8"))` misreports on-disk size

Gates: pytest (651 passed, 42 in corpus suite), mypy --strict, ruff. CLI smoke verified for default / --encode-last 5 / --no-encode modes.