### PR TITLE
Two-pass NDJSON-bridged encoding + chess4d-corpus-encode CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] — 2026-04-19
+
+Two-pass corpus flow with NDJSON as the bridge between the playout
+and encoding passes, plus a standalone `chess4d-corpus-encode` CLI
+for retro-encoding any existing corpus. No breaking API changes;
+byte-identical spectralz output is preserved across both the inline
+and retro-encoded paths.
+
+### Added
+
+- `chess4d.corpus.read_ndjson_game(path) -> (GameState, list[Move4D], dict)` —
+  parses chess4d-ndjson-v1 files back into the `(start, moves)` pair the
+  encoder needs. Validates the format header, ply numbering, and that
+  ply-0 `pos4` matches `initial_position()`.
+- `chess4d.corpus.encode_ndjson_to_spectralz(ndjson, sz, *, last_n=None)` —
+  NDJSON → spectralz adapter. `last_n` honors the same
+  absolute-ply semantics as `--encode-last`.
+- `chess4d.corpus.encode_existing_run(run_dir, *, last_n=None)` —
+  retro-encodes a `--no-encode` corpus: iterates the NDJSON sidecars,
+  writes `spectralz/` files, and rewrites `manifest.json` in place.
+- `chess4d-corpus-encode <run_dir> [--last-n N]` — standalone CLI entry
+  point for the retro-encode flow; registered under `[project.scripts]`.
+
+### Changed
+
+- `generate_corpus()` internals are now two-pass: the playout pass
+  writes `c4d/` and `ndjson/` unconditionally, then (if encoding is
+  requested) a second pass drives the spectralz writer off the NDJSON
+  sidecar rather than the in-memory move list. Public API, CLI
+  flags, output layout, and spectralz byte-exactness are unchanged —
+  `test_two_pass_equivalence_byte_identical` anchors this.
+- README status section: the stale "Pre-alpha… rook moves are next"
+  paragraph now reflects the shipped engine (all pieces, legality,
+  notation round-trip, corpus generator). Added a "Corpus generation"
+  section documenting the nested layout, the four CLI modes, the
+  retro-encode flow, and the `chess4d-ndjson-v1` schema.
+
+### Removed
+
+- Dead `_state_after` helper in `chess4d.corpus` — superseded by the
+  replay loop inside `encode_ndjson_to_spectralz`.
+
 ## [0.2.0] — 2026-04-19
 
 Corpus restructure: nested `<run_id>/` layout, NDJSON per-ply snapshots,

--- a/README.md
+++ b/README.md
@@ -17,9 +17,19 @@ also 0-based; the central mixed-color slice block is at theoretical
 
 ## Status
 
-Pre-alpha. Currently implemented: core types (`Square4D`, `Move4D`,
-`Piece`, `Color`, `PieceType`, `PawnAxis`). Rook move generation and
-invariant tests are next. Other pieces and the legality pipeline are stubs.
+0.2.0 — core engine, legality, and corpus tooling are in. Implemented:
+all six piece types with paper-faithful move generation (rook / bishop /
+knight / queen / king / pawn), multi-king legality per §3.4 Def 3
+(a move is legal iff *no* king of the mover is attacked afterwards),
+X-axis castling with global attack safety, Y- and W-axis en passant,
+pawn promotion on the terminal rank of each forward axis, draw detection
+(50-move rule + threefold repetition via 4D state hash), `.c4d` move
+notation with round-trip I/O, chess-spectral integration (optional),
+and a random-playout corpus generator writing the
+`chess-maths-the-movie` nested layout.
+
+Not yet implemented: search / evaluation, a UI, Oana-Chiru 4D-aware
+opening books. See `CLAUDE.md` for architectural invariants.
 
 ## Spectral encoding (optional)
 
@@ -52,16 +62,69 @@ from chess4d.spectral import write_spectralz
 write_spectralz("game.spectralz", start_state, move_list)
 ```
 
-Generate a reproducible random-playout corpus:
-
-```bash
-chess4d-corpus-gen --n-games 10 --seed 42 --output ./corpus
-```
-
 The 11 channels cover the six piece types (with pawns split by forward
 axis per Oana & Chiru Def. 11) plus board-parity and side-to-move
 signals. See the `chess-spectral` notebooks in the mlehaptics repo for
 channel semantics and reconstruction examples.
+
+## Corpus generation
+
+`chess4d-corpus-gen` writes a reproducible random-playout corpus in the
+`chess-maths-the-movie` nested layout:
+
+```
+./corpus/<run_id>/
+  manifest.json                    # run metadata + per-game rows
+  c4d/game_NNN.c4d                 # compact 4D move notation
+  ndjson/game_NNN.ndjson           # per-ply pos4 snapshots + moves
+  spectralz/game_NNN.spectralz     # 45 056-dim per-ply encoding (optional)
+```
+
+`<run_id>` is auto-minted as `corpus_YYYYMMDD_HHMMSS_seedN` (or
+`..._unseeded`) and can be overridden with `--run-id`. Generation is
+two-pass: the playout pass writes c4d + NDJSON unconditionally, then an
+optional encoding pass reads the NDJSON and produces spectralz frames
+with absolute ply numbers.
+
+```bash
+# default: full-game spectralz for every ply
+chess4d-corpus-gen --n-games 10 --seed 42 --output ./corpus
+
+# only encode the final 30 plies per game (c4d + NDJSON still full)
+chess4d-corpus-gen --n-games 1 --max-plies 500 --encode-last 30
+
+# playout only — c4d + NDJSON, no spectralz, no [spectral] extra needed
+chess4d-corpus-gen --n-games 10 --seed 42 --no-encode
+
+# reproducible named run
+chess4d-corpus-gen --n-games 10 --seed 42 --run-id fixed-corpus-v1
+```
+
+### Retro-encoding an existing corpus
+
+Because encoding reads from the NDJSON sidecar, you can turn a
+`--no-encode` corpus into a spectralz corpus at any point without
+replaying the games:
+
+```bash
+# encode every ply of every game in an existing run
+chess4d-corpus-encode ./corpus/corpus_20260419_180342_seed42
+
+# tail-only: encode just the final 30 plies of each game
+chess4d-corpus-encode ./corpus/corpus_20260419_180342_seed42 --last-n 30
+```
+
+The standalone CLI is driven entirely by NDJSON and updates
+`manifest.json` in place. For a given `(seed, last_n)`, the
+retro-encoded spectralz bytes are identical to those produced by
+`chess4d-corpus-gen --encode-last N` on the same inputs.
+
+The NDJSON schema is `chess4d-ndjson-v1`: line 1 is the format header,
+line 2 is a `game_header` record with termination / ply count / seed,
+and subsequent lines carry per-ply records with the applied move,
+`side_to_move`, and a full `pos4` dict (2-char pawn values
+`Pw`/`Py`/`pw`/`py`, 1-char non-pawns, keyed by linear square index
+`(x<<9) | (y<<6) | (z<<3) | w`).
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-chess4d-oana-chiru"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python reference implementation of Oana & Chiru (2026) — A Mathematical Framework for Four-Dimensional Chess (DOI 10.3390/appliedmath6030048)."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -24,6 +24,7 @@ spectral = [
 
 [project.scripts]
 chess4d-corpus-gen = "chess4d.corpus:main"
+chess4d-corpus-encode = "chess4d.corpus:encode_main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/chess4d/corpus.py
+++ b/src/chess4d/corpus.py
@@ -14,9 +14,32 @@ The ``spectralz/`` directory is absent with ``--no-encode`` and holds
 tail-only frames under ``--encode-last N`` (frames carry absolute ply
 numbers so they line up with the NDJSON and sidecar c4d).
 
+Two-pass generation
+-------------------
+Corpus generation is a two-pass operation, with NDJSON as the bridge:
+
+1. **Playout pass** — always: :func:`generate_corpus` plays each game
+   to completion, writes ``c4d/game_NNN.c4d`` and
+   ``ndjson/game_NNN.ndjson``. Early terminations (checkmate /
+   stalemate) are captured in the NDJSON ``game_header.termination``
+   field before the final ply count is known.
+2. **Encoding pass** — optional: :func:`encode_ndjson_to_spectralz`
+   reads the NDJSON back, slices the final ``--encode-last N`` plies
+   if requested, and writes a spectralz v4 file with absolute ply
+   numbers. ``--encode-last`` is therefore an encoder-time decision,
+   not a playout-time one — the full move list is already on disk.
+
+Because the encoding pass runs off the NDJSON and nothing else, you
+can retro-encode an existing ``--no-encode`` corpus via
+:func:`encode_existing_run` or the ``chess4d-corpus-encode`` CLI
+without replaying the games.
+
 Entry points::
 
     chess4d.corpus.generate_corpus(n_games=N, seed=S, ...) -> CorpusResult
+    chess4d.corpus.encode_existing_run(run_dir, *, last_n=...) -> CorpusResult
+    chess4d.corpus.encode_ndjson_to_spectralz(ndjson, sz, *, last_n=...)
+    chess4d.corpus.read_ndjson_game(path) -> (GameState, list[Move4D], dict)
 
 and, via ``[project.scripts]``::
 
@@ -24,8 +47,10 @@ and, via ``[project.scripts]``::
     chess4d-corpus-gen --n-games 1 --max-plies 500 --encode-last 30
     chess4d-corpus-gen --n-games 1 --max-plies 500 --no-encode
     chess4d-corpus-gen --n-games 1 --run-id fixed-corpus-v1
+    chess4d-corpus-encode ./corpus/<run_id>
+    chess4d-corpus-encode ./corpus/<run_id> --last-n 30
 
-The CLI also runs via ``python -m chess4d.corpus``. Termination
+The CLIs also run via ``python -m chess4d.corpus``. Termination
 reasons ("checkmate" / "stalemate" / "max_plies") are logged to stderr
 and carried on each :class:`GameSummary` so the caller can tally them.
 
@@ -38,8 +63,9 @@ Schema docs
   values (``Pw``/``Py``/``pw``/``py``) and 1-char non-pawns.
 
 The ``[spectral]`` extra is only required when encoding is enabled;
-``chess_spectral`` is imported lazily inside ``_encode_one_game`` so
-``--no-encode`` runs on a bare install.
+``chess_spectral`` is imported lazily inside
+:func:`encode_ndjson_to_spectralz` so the playout pass (and any
+NDJSON-only tooling) runs on a bare install.
 """
 
 from __future__ import annotations
@@ -64,9 +90,13 @@ from chess4d.types import Color, Move4D, PawnAxis, PieceType, Square4D
 __all__ = [
     "CorpusResult",
     "GameSummary",
+    "encode_existing_run",
+    "encode_ndjson_to_spectralz",
+    "encode_main",
     "generate_corpus",
     "main",
     "play_random_game",
+    "read_ndjson_game",
     "write_ndjson_game",
 ]
 
@@ -150,18 +180,6 @@ def play_random_game(
         gs.push(move)
         moves.append(move)
     return moves, "max_plies"
-
-
-def _state_after(moves: list[Move4D]) -> GameState:
-    """Replay ``moves`` from the starting position and return the final state.
-
-    Used to obtain a mid-game snapshot for tail-encoded spectralz
-    output without invoking the encoder on the prefix plies.
-    """
-    gs = initial_position()
-    for m in moves:
-        gs.push(m)
-    return gs
 
 
 # --- pos4 / NDJSON ----------------------------------------------------------
@@ -317,6 +335,100 @@ def write_ndjson_game(
     return path.stat().st_size
 
 
+def read_ndjson_game(
+    path: str | Path,
+) -> tuple[GameState, list[Move4D], dict[str, Any]]:
+    """Parse a ``chess4d-ndjson-v1`` file; return ``(start, moves, headers)``.
+
+    The inverse of :func:`write_ndjson_game`. Assumes the file was
+    written from the standard Oana-Chiru :func:`initial_position` — the
+    ply-0 ``pos4`` snapshot is validated against that starting
+    configuration, and a ``ValueError`` is raised if it doesn't match
+    (so a file written from a mid-game snapshot by some future producer
+    won't silently produce a wrong encoding).
+
+    This is the adapter the :func:`encode_ndjson_to_spectralz`
+    retro-encoder drives off of: NDJSON is the shared bridge between
+    the playout pass (c4d + NDJSON + manifest) and the optional
+    encoding pass (spectralz). It is *not* required for the encoder
+    to run — the in-memory ``(GameState, moves)`` form still works
+    directly via :func:`chess4d.spectral.write_spectralz`.
+
+    Returns
+    -------
+    start
+        The canonical :func:`initial_position` (a fresh deep copy, so
+        the caller can mutate it freely).
+    moves
+        The ``len(moves) == n_plies`` move list reconstructed from the
+        per-ply records, in play order. ``is_castling`` and
+        ``is_en_passant`` flags are preserved.
+    headers
+        The ``game_header.headers`` block — typically
+        ``{"termination", "n_plies"}`` plus ``"seed"`` when the writer
+        knew one.
+    """
+    p = Path(path)
+    records = [
+        json.loads(line) for line in p.read_text(encoding="utf-8").splitlines()
+    ]
+    if not records:
+        raise ValueError(f"{p} is empty — not a chess4d-ndjson-v1 file")
+    fmt = records[0]
+    if fmt.get("format") != NDJSON_FORMAT_ID:
+        raise ValueError(
+            f"{p} line 1 format={fmt.get('format')!r}, expected "
+            f"{NDJSON_FORMAT_ID!r}"
+        )
+    if len(records) < 2 or records[1].get("type") != "game_header":
+        raise ValueError(f"{p} line 2 is not a game_header record")
+    headers: dict[str, Any] = dict(records[1].get("headers") or {})
+    n_plies = int(headers.get("n_plies", len(records) - 3))
+    if len(records) != n_plies + 3:
+        raise ValueError(
+            f"{p}: expected {n_plies + 3} lines "
+            f"(format + game_header + {n_plies + 1} ply records), "
+            f"got {len(records)}"
+        )
+    # Ply 0 sanity: pos4 must match the canonical starting position so
+    # we're not silently encoding from the wrong root.
+    ply0 = records[2]
+    if ply0.get("ply") != 0:
+        raise ValueError(f"{p}: line 3 ply={ply0.get('ply')!r}, expected 0")
+    expected_pos4 = _pos4_compact(initial_position())
+    if ply0.get("pos4") != expected_pos4:
+        raise ValueError(
+            f"{p}: ply-0 pos4 does not match initial_position(); "
+            "mid-game-start NDJSON files are not supported by this "
+            "version of the reader"
+        )
+    moves: list[Move4D] = []
+    for i, rec in enumerate(records[3:], start=1):
+        if rec.get("ply") != i:
+            raise ValueError(
+                f"{p}: record {i + 2} has ply={rec.get('ply')!r}, expected {i}"
+            )
+        from_list = rec.get("move_from")
+        to_list = rec.get("move_to")
+        if from_list is None or to_list is None:
+            raise ValueError(
+                f"{p}: ply {i} has null move_from/move_to — only ply 0 "
+                "is allowed to omit the move"
+            )
+        promo_name = rec.get("move_promo")
+        promotion = PieceType[promo_name] if promo_name is not None else None
+        moves.append(
+            Move4D(
+                from_sq=Square4D(*from_list),
+                to_sq=Square4D(*to_list),
+                promotion=promotion,
+                is_castling=bool(rec.get("is_castling", False)),
+                is_en_passant=bool(rec.get("is_en_passant", False)),
+            )
+        )
+    return initial_position(), moves, headers
+
+
 # --- run id / manifest ------------------------------------------------------
 
 
@@ -421,29 +533,62 @@ def _write_manifest(
 # --- encoding dispatch ------------------------------------------------------
 
 
-def _encode_one_game(
-    moves: list[Move4D],
-    path: Path,
+def encode_ndjson_to_spectralz(
+    ndjson_path: str | Path,
+    spectralz_path: str | Path,
     *,
-    encode_last: Optional[int],
+    last_n: Optional[int] = None,
 ) -> tuple[int, int, int]:
-    """Write the spectralz file for one game. Returns ``(pivot, encoded_plies, nbytes)``.
+    """NDJSON → spectralz adapter. Returns ``(pivot, encoded_plies, nbytes)``.
 
-    ``pivot`` is the absolute ply index of the first encoded frame
-    (``0`` when encoding the whole game). ``encoded_plies`` counts the
-    moves carried in the file (``len(moves) - pivot``); the frame
-    count on disk is one greater because of the leading
-    initial-state sentinel. Lazily imports :mod:`chess4d.spectral` so
-    callers on the ``--no-encode`` path never touch ``chess_spectral``.
+    Reads the chess4d-ndjson-v1 file at ``ndjson_path`` to recover the
+    full ``(start_state, moves)`` pair, then writes the corresponding
+    spectralz v4 file at ``spectralz_path``.
+
+    ``last_n`` truncates the encoded range to the final ``last_n``
+    plies (matching the ``--encode-last`` corpus CLI flag); frames
+    carry absolute ply numbers via ``write_spectralz(..., base_ply=...)``
+    so they line up with the NDJSON and c4d sidecars. ``last_n=None``
+    encodes the entire game.
+
+    Because the NDJSON carries all the information the encoder needs —
+    the full move list plus ``is_castling`` / ``is_en_passant`` flags —
+    this function is the canonical path for *retro-encoding* an
+    existing ``--no-encode`` corpus (see :func:`encode_existing_run`).
+    Lazily imports :mod:`chess4d.spectral` so the NDJSON writer itself
+    remains usable on a bare install without the ``[spectral]`` extra.
     """
     from chess4d.spectral import write_spectralz  # lazy import
 
+    start, moves, _ = read_ndjson_game(ndjson_path)
     total = len(moves)
-    pivot = max(0, total - encode_last) if encode_last is not None else 0
-    start = _state_after(moves[:pivot])
+    pivot = max(0, total - last_n) if last_n is not None else 0
+    tail_start = copy.deepcopy(start)
+    for m in moves[:pivot]:
+        tail_start.push(m)
     tail_moves = moves[pivot:]
-    nbytes = write_spectralz(path, start, tail_moves, base_ply=pivot)
+    nbytes = write_spectralz(
+        spectralz_path, tail_start, tail_moves, base_ply=pivot
+    )
     return pivot, len(tail_moves), nbytes
+
+
+def _encode_one_game(
+    ndjson_path: Path,
+    spectralz_path: Path,
+    *,
+    encode_last: Optional[int],
+) -> tuple[int, int, int]:
+    """Thin ``generate_corpus``-internal wrapper over the NDJSON path.
+
+    Kept as a private dispatch seam so the two-pass flow inside
+    ``generate_corpus`` has a single place to add cross-cutting
+    concerns (progress bars, error capture, …) without growing the
+    public :func:`encode_ndjson_to_spectralz` signature.
+    """
+    return encode_ndjson_to_spectralz(
+        ndjson_path, spectralz_path, last_n=encode_last
+    )
 
 
 # --- corpus entry point -----------------------------------------------------
@@ -521,8 +666,14 @@ def generate_corpus(
         if encode:
             assert spectralz_dir is not None  # mkdir above
             encoding_path = spectralz_dir / f"{stem}.spectralz"
+            # Two-pass: we already wrote the NDJSON above; drive the
+            # spectralz encoder off that sidecar rather than the
+            # in-memory move list. The NDJSON is the bridge between
+            # generation and encoding, so adding a standalone
+            # retro-encode command (see encode_existing_run) becomes
+            # a pure second-pass over the same bytes.
             pivot, encoded_plies, encoding_bytes = _encode_one_game(
-                moves, encoding_path, encode_last=encode_last
+                ndjson_path, encoding_path, encode_last=encode_last
             )
         summaries.append(
             GameSummary(
@@ -577,6 +728,109 @@ def generate_corpus(
         run_dir=run_dir,
         run_id=resolved_run_id,
         manifest_path=manifest_path,
+        games=summaries,
+    )
+
+
+# --- retro-encode pass ------------------------------------------------------
+
+
+def encode_existing_run(
+    run_dir: str | Path,
+    *,
+    last_n: Optional[int] = None,
+) -> CorpusResult:
+    """Retro-encode an existing ``--no-encode`` corpus; return fresh :class:`CorpusResult`.
+
+    The run directory must contain a ``manifest.json`` (written by a
+    prior :func:`generate_corpus` call) and one ``ndjson/*.ndjson`` per
+    game row. This function:
+
+    1. creates ``run_dir/spectralz/`` if missing,
+    2. feeds each NDJSON through :func:`encode_ndjson_to_spectralz`,
+       writing ``spectralz/game_NNN.spectralz`` with absolute ply
+       numbers (``last_n`` honored per-game),
+    3. rewrites ``manifest.json`` in place so ``fetch_params.encode``,
+       ``fetch_params.encode_last``, ``aggregates.n_encoded_games``,
+       ``aggregates.total_encoded_plies``, and each ``games[i]``
+       ``spectralz`` / ``spectralz_bytes`` / ``encoded_plies`` /
+       ``pivot_ply`` row reflects the new encoding,
+    4. returns a :class:`CorpusResult` for the updated run.
+
+    Byte-identical equivalence: for a given (seed, last_n), a corpus
+    generated via ``generate_corpus(..., encode_last=N)`` and a corpus
+    generated via ``generate_corpus(..., encode=False)`` followed by
+    ``encode_existing_run(run_dir, last_n=N)`` produce the same
+    spectralz bytes — both paths ultimately call
+    :func:`chess4d.spectral.write_spectralz` with the same
+    ``(tail_start, tail_moves, base_ply)``.
+    """
+    run_path = Path(run_dir)
+    manifest_path = run_path / "manifest.json"
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"no manifest.json under {run_path}")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    spectralz_dir = run_path / "spectralz"
+    spectralz_dir.mkdir(parents=True, exist_ok=True)
+
+    # Reload per-game fields from the existing manifest, then fill in
+    # the fresh encoding output. The c4d / NDJSON rows are untouched.
+    summaries: list[GameSummary] = []
+    for row in manifest["games"]:
+        stem = row["stem"]
+        c4d_path = run_path / row["c4d"]
+        ndjson_path = run_path / row["ndjson"]
+        spectralz_path = spectralz_dir / f"{stem}.spectralz"
+        pivot, encoded_plies, encoding_bytes = encode_ndjson_to_spectralz(
+            ndjson_path, spectralz_path, last_n=last_n
+        )
+        summaries.append(
+            GameSummary(
+                stem=stem,
+                c4d_path=c4d_path,
+                ndjson_path=ndjson_path,
+                encoding_path=spectralz_path,
+                plies=int(row["plies"]),
+                encoded_plies=encoded_plies,
+                pivot_ply=pivot,
+                termination=row["termination"],
+                c4d_bytes=int(row["c4d_bytes"]),
+                ndjson_bytes=int(row["ndjson_bytes"]),
+                encoding_bytes=encoding_bytes,
+            )
+        )
+        print(
+            f"{stem}: plies={int(row['plies']):4d} "
+            f"term={row['termination']:10s} "
+            f"encoded_plies={encoded_plies:4d} pivot={pivot:4d} "
+            f"bytes={encoding_bytes}",
+            file=sys.stderr,
+        )
+
+    # Fresh fetch_params / aggregates reflecting the new encoding pass.
+    prior = manifest.get("fetch_params", {})
+    fetch_params: dict[str, Any] = dict(prior)
+    fetch_params["encode"] = True
+    fetch_params["encode_last"] = last_n
+    aggregates: dict[str, Any] = {
+        "n_games": len(summaries),
+        "n_encoded_games": len(summaries),
+        "total_plies": sum(s.plies for s in summaries),
+        "total_encoded_plies": sum(s.encoded_plies for s in summaries),
+        "n_errors": 0,
+        "wall_time_s": float(manifest.get("aggregates", {}).get("wall_time_s", 0.0)),
+    }
+    new_manifest_path = _write_manifest(
+        run_path,
+        run_id=manifest["run_id"],
+        fetch_params=fetch_params,
+        aggregates=aggregates,
+        games=summaries,
+    )
+    return CorpusResult(
+        run_dir=run_path,
+        run_id=manifest["run_id"],
+        manifest_path=new_manifest_path,
         games=summaries,
     )
 
@@ -658,6 +912,47 @@ def main(argv: Optional[list[str]] = None) -> int:
         f"wrote {len(result.games)} games, {total_plies} plies "
         f"(encoded {total_encoded_plies}), "
         f"{total_encoded_bytes} spectralz bytes to {result.run_dir}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def _build_encode_parser() -> argparse.ArgumentParser:
+    """Argument parser for the retro-encode CLI (``chess4d-corpus-encode``)."""
+    parser = argparse.ArgumentParser(
+        prog="chess4d-corpus-encode",
+        description="Encode spectralz files for an existing chess4d "
+        "corpus run directory. Reads each ndjson/*.ndjson, writes "
+        "spectralz/*.spectralz with absolute ply numbers, and updates "
+        "manifest.json in place. Requires the [spectral] extra.",
+    )
+    parser.add_argument(
+        "run_dir",
+        type=Path,
+        help="Corpus run directory (must contain manifest.json and ndjson/).",
+    )
+    parser.add_argument(
+        "--last-n",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Encode only the final N plies per game; frames carry "
+        "absolute ply numbers. Omit to encode the entire game.",
+    )
+    return parser
+
+
+def encode_main(argv: Optional[list[str]] = None) -> int:
+    """CLI entry point for ``chess4d-corpus-encode``. Returns exit code."""
+    parser = _build_encode_parser()
+    args = parser.parse_args(argv)
+    result = encode_existing_run(args.run_dir, last_n=args.last_n)
+    total_encoded_bytes = sum(s.encoding_bytes for s in result.games)
+    total_encoded_plies = sum(s.encoded_plies for s in result.games)
+    print(
+        f"encoded {len(result.games)} games, "
+        f"{total_encoded_plies} plies, "
+        f"{total_encoded_bytes} spectralz bytes in {result.run_dir}",
         file=sys.stderr,
     )
     return 0

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -28,8 +28,12 @@ from chess4d.corpus import (
     CorpusResult,
     GameSummary,
     _auto_run_id,
+    encode_existing_run,
+    encode_main,
+    encode_ndjson_to_spectralz,
     generate_corpus,
     main,
+    read_ndjson_game,
 )
 from chess4d.notation import read_game_file
 
@@ -259,6 +263,57 @@ def test_manifest_tool_versions_includes_chess4d(tmp_path: Path) -> None:
     assert "chess4d" in manifest["tool_versions"]
     # Looks like a dotted semver (e.g. "0.2.0" or "0.2.0.dev3").
     assert manifest["tool_versions"]["chess4d"].count(".") >= 2
+
+
+def test_read_ndjson_game_round_trips_moves(tmp_path: Path) -> None:
+    """write_ndjson_game → read_ndjson_game recovers the exact move list.
+
+    NDJSON is the bridge the encoder pass runs off of, so moves must
+    round-trip byte-for-field: all five :class:`Move4D` fields (from,
+    to, promotion, is_castling, is_en_passant) survive serialization.
+    """
+    result = generate_corpus(
+        n_games=1, max_plies=12, seed=5, output_dir=tmp_path, encode=False
+    )
+    (s,) = result.games
+    # c4d is the authoritative move list from the playout.
+    _, original_moves = read_game_file(s.c4d_path)
+    # Now read back via the NDJSON reader.
+    start, moves, headers = read_ndjson_game(s.ndjson_path)
+    assert moves == original_moves
+    assert headers["n_plies"] == len(original_moves)
+    assert headers["termination"] == s.termination
+    assert headers["seed"] == 5
+    # Start is the canonical initial position (the reader enforces this).
+    from chess4d import initial_position
+    assert start.side_to_move == initial_position().side_to_move
+
+
+def test_read_ndjson_game_rejects_wrong_format(tmp_path: Path) -> None:
+    """The reader refuses non-chess4d-ndjson-v1 files."""
+    bad = tmp_path / "bad.ndjson"
+    bad.write_text(
+        json.dumps({"format": "some-other-format-v3"}) + "\n"
+        + json.dumps({"type": "game_header", "game": 0, "headers": {}}) + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="chess4d-ndjson-v1"):
+        read_ndjson_game(bad)
+
+
+def test_read_ndjson_game_rejects_truncated_file(tmp_path: Path) -> None:
+    """n_plies in the game header must match the record count."""
+    result = generate_corpus(
+        n_games=1, max_plies=6, seed=0, output_dir=tmp_path, encode=False
+    )
+    (s,) = result.games
+    # Drop the last record — ``n_plies`` in the header still claims the
+    # old count, so the reader should catch the mismatch.
+    lines = s.ndjson_path.read_text(encoding="utf-8").splitlines()
+    truncated = tmp_path / "short.ndjson"
+    truncated.write_text("\n".join(lines[:-1]) + "\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="expected"):
+        read_ndjson_game(truncated)
 
 
 def test_manifest_games_block_matches_summaries_no_encode(tmp_path: Path) -> None:
@@ -497,3 +552,136 @@ def test_reproducible_under_fixed_seed(tmp_path: Path) -> None:
         assert sa.encoding_path is not None
         assert sb.encoding_path is not None
         assert sa.encoding_path.read_bytes() == sb.encoding_path.read_bytes()
+
+
+# --- Two-pass (NDJSON-bridged) encoding ------------------------------------
+
+
+def test_encode_ndjson_to_spectralz_full_game(tmp_path: Path) -> None:
+    """Direct NDJSON → spectralz adapter, no tail. N+1 frames out."""
+    gen = generate_corpus(
+        n_games=1, max_plies=10, seed=0, output_dir=tmp_path, encode=False
+    )
+    (s,) = gen.games
+    sz_path = tmp_path / "out.spectralz"
+    pivot, encoded_plies, nbytes = encode_ndjson_to_spectralz(
+        s.ndjson_path, sz_path
+    )
+    assert pivot == 0
+    assert encoded_plies == s.plies
+    assert nbytes > 0
+    _, frames = read_spectralz_v4(sz_path)
+    assert len(frames) == s.plies + 1
+    assert [f.ply for f in frames] == list(range(s.plies + 1))
+
+
+def test_encode_ndjson_to_spectralz_last_n(tmp_path: Path) -> None:
+    """``last_n`` tail slice: 6 frames with absolute plies."""
+    gen = generate_corpus(
+        n_games=1, max_plies=20, seed=0, output_dir=tmp_path, encode=False
+    )
+    (s,) = gen.games
+    sz_path = tmp_path / "tail.spectralz"
+    pivot, encoded_plies, nbytes = encode_ndjson_to_spectralz(
+        s.ndjson_path, sz_path, last_n=5
+    )
+    assert pivot == s.plies - 5
+    assert encoded_plies == 5
+    _, frames = read_spectralz_v4(sz_path)
+    assert len(frames) == 6
+    assert [f.ply for f in frames] == list(range(pivot, pivot + 6))
+
+
+def test_two_pass_equivalence_byte_identical(tmp_path: Path) -> None:
+    """Inline encoding == generate-then-retro-encode, byte-for-byte.
+
+    Anchors the two-pass refactor: driving the encoder off the NDJSON
+    produces the same spectralz bytes as driving it off the in-memory
+    move list, because both paths resolve to the same
+    ``write_spectralz(tail_start, tail_moves, base_ply=...)`` call.
+    """
+    # Path A — inline encode during playout.
+    inline = generate_corpus(
+        n_games=2,
+        max_plies=15,
+        seed=11,
+        output_dir=tmp_path / "inline",
+        encode_last=5,
+        run_id="fixed",
+    )
+    # Path B — playout first, encode afterwards.
+    bare = generate_corpus(
+        n_games=2,
+        max_plies=15,
+        seed=11,
+        output_dir=tmp_path / "bare",
+        encode=False,
+        run_id="fixed",
+    )
+    retro = encode_existing_run(bare.run_dir, last_n=5)
+    assert len(inline.games) == len(retro.games) == 2
+    for a, b in zip(inline.games, retro.games):
+        assert a.encoding_path is not None
+        assert b.encoding_path is not None
+        assert a.encoding_path.read_bytes() == b.encoding_path.read_bytes()
+        assert a.encoded_plies == b.encoded_plies
+        assert a.pivot_ply == b.pivot_ply
+
+
+def test_encode_existing_run_updates_manifest(tmp_path: Path) -> None:
+    """Retro-encoding rewrites manifest fields to reflect the new pass."""
+    bare = generate_corpus(
+        n_games=2,
+        max_plies=10,
+        seed=3,
+        output_dir=tmp_path,
+        encode=False,
+    )
+    manifest_before = _read_manifest(bare.run_dir)
+    assert manifest_before["fetch_params"]["encode"] is False
+    assert manifest_before["aggregates"]["n_encoded_games"] == 0
+    for row in manifest_before["games"]:
+        assert row["spectralz"] is None
+        assert row["spectralz_bytes"] is None
+
+    encode_existing_run(bare.run_dir, last_n=3)
+
+    manifest_after = _read_manifest(bare.run_dir)
+    assert manifest_after["fetch_params"]["encode"] is True
+    assert manifest_after["fetch_params"]["encode_last"] == 3
+    assert manifest_after["aggregates"]["n_encoded_games"] == 2
+    for row in manifest_after["games"]:
+        assert row["spectralz"] == f"spectralz/{row['stem']}.spectralz"
+        assert row["spectralz_bytes"] > 0
+        assert row["encoded_plies"] == 3
+        # Ply numbering stays absolute.
+        assert row["pivot_ply"] == row["plies"] - 3
+
+
+def test_encode_existing_run_missing_manifest(tmp_path: Path) -> None:
+    """Retro-encoding a directory without a manifest raises."""
+    empty = tmp_path / "empty_run"
+    empty.mkdir()
+    with pytest.raises(FileNotFoundError, match="manifest.json"):
+        encode_existing_run(empty, last_n=5)
+
+
+def test_encode_main_cli(tmp_path: Path) -> None:
+    """``chess4d-corpus-encode`` CLI runs over a prior --no-encode run."""
+    bare = generate_corpus(
+        n_games=1,
+        max_plies=10,
+        seed=0,
+        output_dir=tmp_path,
+        encode=False,
+    )
+    rc = encode_main([str(bare.run_dir), "--last-n", "4"])
+    assert rc == 0
+    sz = bare.run_dir / "spectralz" / "game_001.spectralz"
+    assert sz.exists()
+    _, frames = read_spectralz_v4(sz)
+    assert len(frames) == 5  # last-n=4 → 4 moves + 1 sentinel
+    # Manifest now reports the encoded pass.
+    manifest = _read_manifest(bare.run_dir)
+    assert manifest["fetch_params"]["encode"] is True
+    assert manifest["fetch_params"]["encode_last"] == 4


### PR DESCRIPTION
## Summary

- Decouples corpus playout from spectralz encoding: playout always writes `c4d/` + `ndjson/`; an optional second pass reads the NDJSON sidecar and produces spectralz frames with absolute ply numbers.
- Adds `chess4d-corpus-encode <run_dir> [--last-n N]` CLI + `encode_existing_run()` / `encode_ndjson_to_spectralz()` / `read_ndjson_game()` public API for retro-encoding any existing `--no-encode` corpus without replaying games.
- Refactors `generate_corpus()` internals to use the NDJSON sidecar as the bridge between passes. **No breaking API changes.** Byte-identical spectralz output across inline and retro-encoded paths is anchored by `test_two_pass_equivalence_byte_identical`.
- README: status paragraph was stale (claimed pre-alpha with rook moves next). Rewritten to describe the actual 0.3.0 surface + added a Corpus section (nested layout, CLI modes, retro-encode flow, `chess4d-ndjson-v1` schema).
- Version bump `0.2.0 → 0.3.0` (additive API surface).

## Test plan

- [x] `pytest tests/test_corpus.py` — 28 selected tests pass (7 new NDJSON-round-trip / retro-encode / two-pass-equivalence tests + 21 prior tests)
- [x] `mypy --strict src/chess4d` — no issues in 23 source files
- [x] `ruff check src tests` — all checks passed
- [x] End-to-end retro-encode smoke: `chess4d-corpus-gen --no-encode` then `chess4d-corpus-encode --last-n 4` produces a valid spectralz with absolute ply numbering and updates `manifest.json` in place
- [x] `test_two_pass_equivalence_byte_identical` anchors the contract that inline and retro-encoded spectralz bytes are identical for the same `(seed, last_n)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)