### PR TITLE
Publish to PyPI: trusted-publishing workflow + metadata polish

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -125,3 +125,25 @@ jobs:
           else
             gh release create "$TAG" --title "$TAG" --notes "Auto-tagged by CI on push to main."
           fi
+
+      - name: Dispatch publish-to-pypi workflow
+        # Tags pushed with the default ``GITHUB_TOKEN`` do NOT cascade
+        # a ``push: tags`` trigger on other workflows — this is a
+        # documented GitHub Actions safety rail. ``workflow_dispatch``
+        # is explicitly exempt from that restriction, so we call it
+        # directly here. ``publish-to-pypi.yml`` also listens on
+        # ``push: tags`` for human-initiated tag pushes.
+        if: steps.ver.outputs.skip == 'false' && steps.exists.outputs.exists == 'false'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.ver.outputs.tag }}
+        run: |
+          if [ -f .github/workflows/publish-to-pypi.yml ]; then
+            gh workflow run publish-to-pypi.yml \
+              --ref "$TAG" \
+              --field "tag=$TAG"
+            echo "Dispatched publish-to-pypi.yml at ref $TAG"
+          else
+            echo "::notice::publish-to-pypi.yml not present; skipping PyPI dispatch."
+          fi

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -26,6 +26,16 @@ on:
         required: false
         type: string
 
+# Minimum default for GITHUB_TOKEN; individual jobs may widen via their
+# own ``permissions:`` block (which *replaces*, not merges, the top
+# level — see https://docs.github.com/en/actions/security-for-github-actions/
+# security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token).
+# The ``publish`` job below overrides to add id-token: write for OIDC;
+# the ``build`` job inherits ``contents: read`` which is what it needs
+# for actions/checkout. Flagged by CodeQL otherwise.
+permissions:
+  contents: read
+
 concurrency:
   group: publish-to-pypi
   cancel-in-progress: false

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,91 @@
+name: publish-to-pypi
+
+# Builds and publishes the ``python-chess4d-oana-chiru`` distribution
+# (sdist + wheel) to PyPI whenever a ``vX.Y.Z`` tag lands, or when
+# dispatched manually / by the autotag.yml workflow.
+#
+# Auth: PyPI "trusted publishing" via OIDC — no long-lived tokens.
+# The PyPI project's Publishing settings must reference this repo,
+# this workflow filename, and the ``pypi`` environment below.
+#
+# Trigger paths:
+# 1. Human pushes a ``v*`` tag → ``push: tags`` fires directly.
+# 2. autotag.yml creates a tag (via GITHUB_TOKEN, which wouldn't
+#    cascade a ``push`` event) → autotag.yml explicitly dispatches
+#    this workflow with the tag ref.
+# 3. Manual rerun from the Actions tab → ``workflow_dispatch``.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag ref to publish (e.g. v0.3.1). Defaults to the ref the workflow was dispatched on."
+        required: false
+        type: string
+
+concurrency:
+  group: publish-to-pypi
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (tag ref)
+        uses: actions/checkout@v4
+        with:
+          # When dispatched with an explicit ``tag`` input, check out
+          # exactly that tag so the built artifact matches the release.
+          ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build
+        run: python -m build
+
+      - name: Validate distribution metadata
+        run: python -m twine check --strict dist/*
+
+      - name: Upload artifact for the publish job
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    # The ``pypi`` environment matches the trusted-publisher config on
+    # PyPI. Add branch / tag / required-reviewer protection rules in
+    # the GitHub UI if you want a second pair of eyes on each release.
+    environment:
+      name: pypi
+      url: https://pypi.org/project/python-chess4d-oana-chiru/
+    permissions:
+      id-token: write  # OIDC token for trusted publishing
+    steps:
+      - name: Download built distribution
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # No ``with:`` block — the action defaults to PyPI (not TestPyPI)
+        # and uses OIDC trusted publishing when id-token: write is set.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] — 2026-04-19
+
+Packaging-only release: the project is now installable from PyPI.
+
+### Changed
+
+- `[spectral]` extra now depends on `chess-spectral>=1.1.1` from PyPI
+  instead of the PEP 508 direct reference
+  `chess-spectral @ git+https://github.com/.../mlehaptics.git@chess-spectral-v1.1.1#subdirectory=...`.
+  PyPI rejects uploads whose metadata contains direct references, so
+  the prior form blocked distribution. Same content pinned at the
+  same lower bound; the spectralz-v4 bit-level encoding contract is
+  preserved. No user-visible API change.
+- `[tool.hatch.metadata] allow-direct-references` removed as a
+  consequence — no longer needed without the git+https URL.
+
+### Added
+
+- `src/chess4d/py.typed` marker — downstream users' mypy now sees
+  the engine's type hints without extra configuration (PEP 561).
+- PyPI metadata polish in `pyproject.toml`: `keywords`, `classifiers`
+  (SemVer-stable Trove set: Science/Research, Board Games, Typed,
+  Python 3.11/3.12), and `project.urls` (Homepage, Issues, Changelog,
+  Paper).
+- Explicit `[tool.hatch.build.targets.sdist] include = [...]`
+  allowlist so the uploaded tarball only carries source + user-facing
+  docs (no `.claude/`, `smoke/`, `hoodoos/`, `benches/`, `CLAUDE.md`).
+- `.github/workflows/publish-to-pypi.yml`: OIDC trusted-publishing
+  workflow that builds sdist + wheel, runs `twine check --strict`,
+  and publishes to PyPI via the `pypi` environment. Triggered by
+  `push: tags: ["v*"]`, by `workflow_dispatch`, or by autotag.yml's
+  cascade dispatch (see below).
+- `.github/workflows/autotag.yml`: after a successful tag push, now
+  dispatches `publish-to-pypi.yml` via `gh workflow run`. This is
+  necessary because `GITHUB_TOKEN`-initiated tag pushes do not
+  cascade a `push: tags` trigger on other workflows —
+  `workflow_dispatch` is the documented exemption.
+
 ## [0.3.0] — 2026-04-19
 
 Two-pass corpus flow with NDJSON as the bridge between the playout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,16 @@ Packaging-only release: the project is now installable from PyPI.
 
 ### Changed
 
-- `[spectral]` extra now depends on `chess-spectral>=1.1.1` from PyPI
+- `[spectral]` extra now depends on `chess-spectral>=1.1.3` from PyPI
   instead of the PEP 508 direct reference
   `chess-spectral @ git+https://github.com/.../mlehaptics.git@chess-spectral-v1.1.1#subdirectory=...`.
   PyPI rejects uploads whose metadata contains direct references, so
-  the prior form blocked distribution. Same content pinned at the
-  same lower bound; the spectralz-v4 bit-level encoding contract is
-  preserved. No user-visible API change.
+  the prior form blocked distribution. `1.1.3` is the first (and
+  currently only) PyPI release — `1.1.1` and `1.1.2` were internal
+  packaging iterations before the upload landed — so the minimum
+  bound tracks what downstream can actually resolve. The spectralz-v4
+  bit-level encoding contract is preserved; `tests/test_spectral.py`
+  passes unchanged under the new version.
 - `[tool.hatch.metadata] allow-direct-references` removed as a
   consequence — no longer needed without the git+https URL.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,12 @@ dev = [
 ]
 spectral = [
     # chess-spectral — 45 056-dim 4D encoder + spectralz v4 frame format.
-    # Published to PyPI from the chess-spectral-v1.1.1 tag in the mlehaptics
-    # monorepo; pinned at that lower bound so bit-level encoding contracts
-    # are preserved.
-    "chess-spectral>=1.1.1",
+    # Published to PyPI as ``chess-spectral``; 1.1.3 is the first (and
+    # currently only) PyPI release — the 1.1.1 and 1.1.2 iterations were
+    # internal packaging fixes before upload. Pinned at the current
+    # released lower bound so downstream resolves to a real PyPI version
+    # rather than hitting a "no matching distribution" error.
+    "chess-spectral>=1.1.3",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,41 @@
 [project]
 name = "python-chess4d-oana-chiru"
-version = "0.3.0"
+version = "0.3.1"
 description = "Python reference implementation of Oana & Chiru (2026) — A Mathematical Framework for Four-Dimensional Chess (DOI 10.3390/appliedmath6030048)."
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "Unlicense" }
 authors = [{ name = "Steven Kirkland" }]
+keywords = [
+    "chess",
+    "4d",
+    "four-dimensional-chess",
+    "oana-chiru",
+    "spectral",
+    "research",
+    "board-games",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "License :: Public Domain",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Games/Entertainment :: Board Games",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Typing :: Typed",
+]
 dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/lemonforest/python-chess4d-oana-chiru"
+Issues = "https://github.com/lemonforest/python-chess4d-oana-chiru/issues"
+Changelog = "https://github.com/lemonforest/python-chess4d-oana-chiru/blob/main/CHANGELOG.md"
+Paper = "https://doi.org/10.3390/appliedmath6030048"
 
 [project.optional-dependencies]
 dev = [
@@ -16,10 +45,11 @@ dev = [
     "ruff>=0.4",
 ]
 spectral = [
-    # chess-spectral v1.1.1 (45 056-dim 4D encoder + spectralz v4 frame format)
-    # lives as a subdirectory inside the mlehaptics monorepo. Pinned to the
-    # upstream release tag ``chess-spectral-v1.1.1``.
-    "chess-spectral @ git+https://github.com/lemonforest/mlehaptics.git@chess-spectral-v1.1.1#subdirectory=docs/chess-maths/chess-spectral/python",
+    # chess-spectral — 45 056-dim 4D encoder + spectralz v4 frame format.
+    # Published to PyPI from the chess-spectral-v1.1.1 tag in the mlehaptics
+    # monorepo; pinned at that lower bound so bit-level encoding contracts
+    # are preserved.
+    "chess-spectral>=1.1.1",
 ]
 
 [project.scripts]
@@ -30,15 +60,22 @@ chess4d-corpus-encode = "chess4d.corpus:encode_main"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.hatch.metadata]
-# The [spectral] extra pins chess-spectral to a git+https URL (a PEP 508
-# "direct reference"). Hatchling rejects those by default as a safety
-# measure; this opt-in is required to accept the spectralz-v4 encoder's
-# mlehaptics-subdir install source.
-allow-direct-references = true
-
 [tool.hatch.build.targets.wheel]
 packages = ["src/chess4d"]
+
+[tool.hatch.build.targets.sdist]
+# Explicit allowlist — hatchling's default sdist globs the filesystem,
+# which would otherwise pull in .claude/, smoke/ scratch output, the
+# hoodoos/ source-paper PDF, CLAUDE.md, benches/, etc. Keep the
+# uploaded tarball minimal: source + user-facing docs only.
+include = [
+    "/src/chess4d",
+    "/tests",
+    "/README.md",
+    "/CHANGELOG.md",
+    "/LICENSE",
+    "/pyproject.toml",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Makes the project PyPI-installable and wires CI to auto-publish on every `vX.Y.Z` tag the autotag workflow creates.

The prior blocker was the `[spectral]` extra's PEP 508 direct reference (`chess-spectral @ git+https://...`). PyPI rejects uploads whose metadata contains direct references. Now that `chess-spectral` is published to PyPI from the `chess-spectral-v1.1.3` tag in mlehaptics, the extra becomes a plain version spec and uploads are unblocked.

Bump `0.3.0 → 0.3.1` (packaging-only; **no API change**).

## What this PR does

### `pyproject.toml`
- `[spectral]` extra: `chess-spectral>=1.1.3` (was a git+https URL).
- Removed `[tool.hatch.metadata] allow-direct-references` — no longer needed.
- Added `keywords`, SemVer-stable Trove `classifiers` (Science/Research, Board Games, Typed, Python 3.11/3.12), and `project.urls` (Homepage, Issues, Changelog, Paper DOI).
- Added `[tool.hatch.build.targets.sdist] include = [...]` allowlist so the uploaded tarball carries only source + user-facing docs (no `.claude/`, `smoke/`, `hoodoos/`, `benches/`, `CLAUDE.md`).

### `src/chess4d/py.typed`
PEP 561 marker — downstream users' mypy now sees the engine's type hints without configuration.

### `.github/workflows/publish-to-pypi.yml` (new)
OIDC trusted-publishing workflow. Matches the `pypi` environment + `publish-to-pypi.yml` filename you already configured on the PyPI project. Triggers:
- `push: tags: ["v*"]` — human-initiated tag pushes.
- `workflow_dispatch` — manual reruns from the Actions tab, plus the cascade from autotag.yml.

Steps: build sdist + wheel → `twine check --strict` → upload artifact → publish via `pypa/gh-action-pypi-publish@release/v1`.

### `.github/workflows/autotag.yml` (updated)
After a successful tag push, now calls `gh workflow run publish-to-pypi.yml --ref \$TAG`. This is required because **GITHUB_TOKEN-initiated tag pushes don't cascade a `push: tags` trigger on other workflows**; `workflow_dispatch` is the documented exemption.

## Local verification

- [x] `python -m build` produces clean sdist (131 KB) + wheel.
- [x] `twine check --strict` **PASSED** on both artifacts.
- [x] Wheel contents: only `chess4d/*` + `py.typed` + `dist-info/` metadata.
- [x] Sdist contents: `src/` + `tests/` + `README.md` + `CHANGELOG.md` + `LICENSE` + `pyproject.toml` + `.gitignore` + `PKG-INFO` (69 entries).
- [x] Fresh-venv install of the built wheel: imports succeed, `importlib.metadata.version('python-chess4d-oana-chiru')` reports `0.3.1`.
- [x] `mypy --strict src/chess4d` — no issues.
- [x] `ruff check src tests` — all passed.

## On merge

1. `autotag.yml` reads `pyproject.toml` version `0.3.1`.
2. `v0.3.1` tag doesn't exist yet → annotated tag is created at the merge commit.
3. GitHub Release for `v0.3.1` is published with the `## [0.3.1]` CHANGELOG section as its body.
4. `autotag.yml` dispatches `publish-to-pypi.yml` at `--ref v0.3.1`.
5. `publish-to-pypi.yml` builds, `twine check --strict`, and uploads to PyPI via the `pypi` environment (OIDC).
6. `python-chess4d-oana-chiru` `0.3.1` appears on PyPI.

If step 5 fails for any reason (e.g. first-run trust establishment), the tag + Release still stand and the workflow can be re-run from the Actions tab. No tokens or secrets involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)