### PR TITLE
Grant autotag actions:write so publish dispatch works (0.3.2)

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -28,6 +28,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # needed to push tags + create releases
+      actions: write   # needed for ``gh workflow run`` to dispatch
+                       # publish-to-pypi.yml (POST /actions/workflows/*/
+                       # dispatches requires this scope; default
+                       # GITHUB_TOKEN without it fails 403 on the
+                       # cascade step — see v0.3.1 post-mortem).
     steps:
       - name: Checkout with full history
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.2] — 2026-04-20
 
-Ships the 0.3.1 release content to PyPI. No code changes from 0.3.1 —
-CI-only fix.
+Ships the 0.3.1 release content to PyPI. No engine / API code changes
+from 0.3.1 — this is a CI + docs release.
 
 ### Fixed
 
@@ -20,6 +20,15 @@ CI-only fix.
   requires that scope. The 0.3.1 release hit this: the git tag
   and GitHub Release landed fine, but the publish workflow was
   never dispatched and nothing made it to PyPI.
+
+### Changed
+
+- `README.md` now has an `## Install` section with the PyPI one-liner
+  (`pip install python-chess4d-oana-chiru`) plus the `[spectral]`
+  extra. The Spectral encoding section no longer claims
+  `chess-spectral` is pulled "directly from GitHub" — it comes from
+  PyPI now (0.3.1 made that transition). Status line updated to
+  0.3.2. Added PyPI / Python-versions / license badges at the top.
 
 ## [0.3.1] — 2026-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] — 2026-04-20
+
+Ships the 0.3.1 release content to PyPI. No code changes from 0.3.1 —
+CI-only fix.
+
+### Fixed
+
+- `.github/workflows/autotag.yml`: `maybe-tag` job now has
+  `actions: write` in its `permissions:` block. Without this,
+  `gh workflow run publish-to-pypi.yml ...` fails with
+  `HTTP 403: Resource not accessible by integration` because the
+  dispatches endpoint (`POST /actions/workflows/*/dispatches`)
+  requires that scope. The 0.3.1 release hit this: the git tag
+  and GitHub Release landed fine, but the publish workflow was
+  never dispatched and nothing made it to PyPI.
+
 ## [0.3.1] — 2026-04-19
 
 Packaging-only release: the project is now installable from PyPI.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,39 @@
 # python-chess4d-oana-chiru
 
+[![PyPI](https://img.shields.io/pypi/v/python-chess4d-oana-chiru.svg)](https://pypi.org/project/python-chess4d-oana-chiru/)
+[![Python versions](https://img.shields.io/pypi/pyversions/python-chess4d-oana-chiru.svg)](https://pypi.org/project/python-chess4d-oana-chiru/)
+[![License: Unlicense](https://img.shields.io/badge/license-Unlicense-blue.svg)](LICENSE)
+
 Python reference implementation of:
 
 > Oana & Chiru, *A Mathematical Framework for Four-Dimensional Chess*,
 > MDPI AppliedMath **6**(3):48, 2026. DOI [10.3390/appliedmath6030048](https://doi.org/10.3390/appliedmath6030048).
 
 The source paper lives in `hoodoos/` (treat as read-only reference).
+
+## Install
+
+From [PyPI](https://pypi.org/project/python-chess4d-oana-chiru/) (recommended):
+
+```bash
+# Core engine + corpus CLI (.c4d + NDJSON outputs; no encoder).
+pip install python-chess4d-oana-chiru
+
+# With the chess-spectral encoder pulled in (45 056-dim float32
+# vectors + spectralz v4 frame format; brings numpy/scipy along).
+pip install "python-chess4d-oana-chiru[spectral]"
+```
+
+From source (for local development):
+
+```bash
+git clone https://github.com/lemonforest/python-chess4d-oana-chiru
+cd python-chess4d-oana-chiru
+pip install -e ".[dev,spectral]"
+```
+
+Type hints ship with the package (`py.typed` marker per PEP 561) and are
+checked with `mypy --strict` in CI.
 
 ## Coordinate convention
 
@@ -17,7 +45,7 @@ also 0-based; the central mixed-color slice block is at theoretical
 
 ## Status
 
-0.3.0 — core engine, legality, and corpus tooling are in. Implemented:
+0.3.2 — core engine, legality, and corpus tooling are in. Implemented:
 all six piece types with paper-faithful move generation (rook / bishop /
 knight / queen / king / pawn), multi-king legality per §3.4 Def 3
 (a move is legal iff *no* king of the mover is attacked afterwards),
@@ -33,15 +61,17 @@ opening books. See `CLAUDE.md` for architectural invariants.
 
 ## Spectral encoding (optional)
 
-chess4d integrates with the `chess-spectral` framework (developed in the
-sibling `mlehaptics` repo) for physics-grounded analysis of 4D positions.
-The encoder maps a `GameState` to an 11-channel, 45 056-dimensional
-float32 spectral vector and writes streams of frames as `spectralz` v4
-files. Install with the `spectral` extra (pulls `chess-spectral` directly
-from GitHub, plus numpy and scipy):
+chess4d integrates with the
+[`chess-spectral`](https://pypi.org/project/chess-spectral/) framework
+(developed in the sibling `mlehaptics` repo, published to PyPI) for
+physics-grounded analysis of 4D positions. The encoder maps a
+`GameState` to an 11-channel, 45 056-dimensional float32 spectral
+vector and writes streams of frames as `spectralz` v4 files. Install
+the `spectral` extra to pull in `chess-spectral` (brings numpy + scipy
+along transitively):
 
 ```bash
-pip install -e .[spectral]
+pip install "python-chess4d-oana-chiru[spectral]"
 ```
 
 Encode a single position:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-chess4d-oana-chiru"
-version = "0.3.1"
+version = "0.3.2"
 description = "Python reference implementation of Oana & Chiru (2026) — A Mathematical Framework for Four-Dimensional Chess (DOI 10.3390/appliedmath6030048)."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Post-mortem fix for the `v0.3.1` release: autotag created the tag and GitHub Release fine, but the cascade to `publish-to-pypi.yml` failed with **`HTTP 403: Resource not accessible by integration`** because `gh workflow run` POSTs to `/actions/workflows/*/dispatches`, which requires `actions: write` on the token. The `maybe-tag` job only had `contents: write`.

Fix: add `actions: write` to `maybe-tag`'s `permissions:` block. Bump to `0.3.2` so a new tag flows end-to-end through the fixed workflow (tag → release → dispatch → build → publish).

## State of the world right now

- `v0.3.1` tag exists on main ✅
- `v0.3.1` GitHub Release published ✅
- `v0.3.1` on PyPI ❌ (dispatch failed before upload)

## After this PR merges

1. `autotag.yml` reads `pyproject.toml` = `0.3.2`.
2. `v0.3.2` tag + GitHub Release created.
3. `gh workflow run publish-to-pypi.yml --ref v0.3.2` now succeeds (token has `actions: write`).
4. `publish-to-pypi.yml` builds, `twine check --strict`, uploads via OIDC to PyPI.
5. `python-chess4d-oana-chiru==0.3.2` appears on PyPI — which is the first PyPI release carrying the 0.3.1 content.

## What about `v0.3.1` on PyPI?

Two options — you pick:

- **Option A (do nothing):** leave `v0.3.1` as a git-tag-only release. First PyPI version becomes `0.3.2`. Clean; one fewer version on PyPI to think about.
- **Option B (manually dispatch 0.3.1):** before merging this PR, go to Actions → publish-to-pypi → Run workflow → type `v0.3.1` in the tag input. Uploads 0.3.1 to PyPI using the already-fixed publish workflow (only autotag was broken).

Either way works. 0.3.2 goes out cleanly after merge regardless.

## Locally verified

- [x] `python -m build` → 0.3.2 sdist + wheel
- [x] `twine check --strict` PASSED on both
- [x] Wheel METADATA reports `Version: 0.3.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)