### PR TITLE
README: document corpus-gen seeding semantics + prefix property

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,37 @@ chess4d-corpus-gen --n-games 10 --seed 42 --no-encode
 chess4d-corpus-gen --n-games 10 --seed 42 --run-id fixed-corpus-v1
 ```
 
+### Seeding semantics
+
+`--seed N` seeds a **single `random.Random(N)`** instance that is
+**shared across every game in the run**. The only thing that RNG drives
+is the move choice (`rng.choice(legal_moves)`); the starting position
+is always the canonical Oana-Chiru §3.3 layout and is *not* seeded.
+
+Because the RNG is deterministic, a corpus produced with a given
+`(max_plies, seed)` is actually an **infinite deterministic sequence**
+of games, and `--n-games N` just asks for the first *N* of them. That
+gives you this prefix property:
+
+| Run A | Run B | Overlap |
+|---|---|---|
+| `--n-games 10 --seed 42` | `--n-games 5 --seed 42` | Games 1..5 are byte-identical |
+| `--n-games 3 --seed 42` | `--n-games 100 --seed 42` | Games 1..3 are byte-identical |
+| `--n-games 10 --seed 42` | `--n-games 10 --seed 43` | Share nothing; different stream |
+
+So growing or shrinking `--n-games` *extends* the corpus forward or
+*truncates* it — it never changes earlier games. The same is true of
+all three outputs (`c4d`, `ndjson`, `spectralz`).
+
+What the shared-RNG design **doesn't** give you is the ability to
+reproduce game *i* in isolation: to get game 5's exact moves you have
+to run games 1..4 first, because game 5's starting RNG state is "seed
+42, advanced past the draws games 1..4 consumed." Per-game seed
+derivation (so each game's RNG is derived independently from the base
+seed + game index) is deliberately deferred to a future release — the
+corpus-level seed is enough for the full-corpus replay use case, which
+is what the `fetch_params.seed` field in `manifest.json` records.
+
 ### Retro-encoding an existing corpus
 
 Because encoding reads from the NDJSON sidecar, you can turn a


### PR DESCRIPTION
## Summary

Recovers the seeding-semantics docs that got orphaned on the `fix/autotag-actions-write-permission` branch after PR #13 was merged. Those commits were pushed *after* the merge, so they never made it into `main` — this PR is a clean re-submission of that content.

Adds a `### Seeding semantics` subsection under `## Corpus generation` that explains:

- `--seed N` seeds a **single `random.Random(N)`** shared across all games in the run; drives move choice only. Starting position isn't seeded (always the paper §3.3 layout).
- The RNG is deterministic, so a corpus is a **prefix of an infinite deterministic game sequence**. `--n-games K` and `--n-games K+N` with the same seed give K byte-identical leading games + N new trailing games.
- Truth table showing the prefix property in action.
- The real limitation: game *i* isn't independently reproducible — you have to replay games 1..i-1 first to advance the RNG. Per-game seed derivation is on the roadmap; the corpus-level seed is enough for full-corpus replay (what `manifest.json`'s `fetch_params.seed` captures).

## Empirically verified

`--n-games 5 --seed 42` and `--n-games 3 --seed 42` produce byte-identical c4d + NDJSON for games 1..3 on this checkout.

## Context

The discussion that produced this section started from an excellent pushback: my first draft claimed games could differ between overlapping runs, which would have been a real bug if true. The prefix property is the correct property and is actually *better* than what I'd initially described — the shared-RNG design is more deterministic than it sounds.

## Incidental

- Deleted the stale `fix/autotag-actions-write-permission` branch from the remote (merged via PR #13; the two orphan commits are rolled into this PR).
- Confirmed `python-chess4d-oana-chiru 0.3.2` is live on PyPI ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)