### PR TITLE
Correctness: pick up chess-spectral 1.2.3 B1/B2 fix + lazy-import cleanup (0.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,79 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] — 2026-04-23
+
+**Correctness release — picks up the upstream D₄×Z₂ B1/B2
+character-table fix in `chess-spectral` 1.2.2. Users doing
+downstream research on 4D encodings produced by chess4d ≤ 0.3.2
+should consider those encodings suspect and re-run against
+0.3.3.**
+
+### Fixed (via upstream `chess-spectral` 1.2.2)
+
+- **D₄×Z₂ irrep projector characters.** `chess-spectral` ≤ 1.1.3
+  carried a `B1`/`B2` character table of
+  `[1, −1, 1, −1, 1, −1, 1, −1]`, inherited from an old chess
+  convention whose axis-vs-diagonal ordering was swapped relative
+  to the D₄ element numbering used by the encoder. That pattern
+  treated `g4` and `g5` (axis reflections, **same conjugacy
+  class**) as opposite-signed — characters must be constant on
+  conjugacy classes, so the projector was **not idempotent** and
+  the B1/B2-channel contributions to the 45 056-dimensional
+  4D encoding were wrong. Verified upstream via direct
+  conjugation: `g1 · g4 · g1⁻¹ = g5`, `g1 · g6 · g1⁻¹ = g7`.
+
+  Corrected tables (now in `chess-spectral` ≥ 1.2.2):
+  - `B1 = [1, −1, 1, −1, +1, +1, −1, −1]`  (+1 on axis, −1 on diagonals)
+  - `B2 = [1, −1, 1, −1, −1, −1, +1, +1]`  (−1 on axis, +1 on diagonals)
+
+  chess4d itself never implemented any of this math — the D₄×Z₂
+  projectors live entirely inside `chess_spectral.encoder_4d` and
+  our `chess4d.spectral` module is a thin adapter over
+  `encode_4d(pos4)` / `write_spectralz_v4(...)`. So no python code
+  in this repo changed; the fix flows in as a dependency bump.
+  Corresponding values-level difference: `encode_position(gs)`
+  and every `spectralz` file written by 0.3.3 are numerically
+  different from 0.3.2 for identical input positions, but the
+  determinism / round-trip / reproducibility-under-seed guarantees
+  our tests anchor on still hold.
+
+### Changed
+
+- `[spectral]` extra: `chess-spectral>=1.1.3` →
+  `chess-spectral[corpus]>=1.2.2`. The `[corpus]` extra is a
+  **temporary workaround** — `chess-spectral` 1.2.2's
+  `__init__.py` eagerly imports `phase_operators.occupation_field`,
+  which does an unconditional `import chess` (the `python-chess`
+  2D library). 4D-only users hit
+  `ModuleNotFoundError: No module named 'chess'` on
+  `import chess_spectral` unless `python-chess` is present. The
+  `[corpus]` extra is upstream's sanctioned way to pull
+  `python-chess` as a transitive dep. When a future
+  `chess-spectral` release makes that import lazy, we'll drop
+  `[corpus]` from the line and the comment in `pyproject.toml`
+  explains the expected cleanup. Net cost to downstream: one extra
+  transitive wheel (`python-chess`, ≈2 MB) for now.
+
+### Notes for research users
+
+If you have `.spectralz` files or downstream analysis derived
+from chess4d 0.3.0 – 0.3.2, the per-position 45 056-dim vectors
+they carry reflect the buggy B1/B2 projectors and shouldn't be
+mixed with 0.3.3-generated data. Re-encode the source games to
+produce a refreshed corpus:
+
+```bash
+pip install --upgrade "python-chess4d-oana-chiru[spectral]"
+# For NDJSON-based corpora, retro-encode in place:
+chess4d-corpus-encode ./corpus/<run_id>
+```
+
+`chess4d-corpus-encode` reads the NDJSON sidecar and rewrites
+the `spectralz/` files (and `manifest.json`) in place, so you
+don't need to replay games. `c4d` and NDJSON sidecars are
+unaffected by the projector fix.
+
 ## [0.3.2] — 2026-04-20
 
 Ships the 0.3.1 release content to PyPI. No engine / API code changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.3] — 2026-04-23
 
 **Correctness release — picks up the upstream D₄×Z₂ B1/B2
-character-table fix in `chess-spectral` 1.2.2. Users doing
-downstream research on 4D encodings produced by chess4d ≤ 0.3.2
-should consider those encodings suspect and re-run against
-0.3.3.**
+character-table fix in `chess-spectral`. Users doing downstream
+research on 4D encodings produced by chess4d ≤ 0.3.2 should
+consider those encodings suspect and re-run against 0.3.3.**
 
-### Fixed (via upstream `chess-spectral` 1.2.2)
+### Fixed (via upstream `chess-spectral`)
 
 - **D₄×Z₂ irrep projector characters.** `chess-spectral` ≤ 1.1.3
   carried a `B1`/`B2` character table of
@@ -27,7 +26,7 @@ should consider those encodings suspect and re-run against
   4D encoding were wrong. Verified upstream via direct
   conjugation: `g1 · g4 · g1⁻¹ = g5`, `g1 · g6 · g1⁻¹ = g7`.
 
-  Corrected tables (now in `chess-spectral` ≥ 1.2.2):
+  Corrected tables (landed in `chess-spectral` 1.2.2):
   - `B1 = [1, −1, 1, −1, +1, +1, −1, −1]`  (+1 on axis, −1 on diagonals)
   - `B2 = [1, −1, 1, −1, −1, −1, +1, +1]`  (−1 on axis, +1 on diagonals)
 
@@ -36,28 +35,29 @@ should consider those encodings suspect and re-run against
   our `chess4d.spectral` module is a thin adapter over
   `encode_4d(pos4)` / `write_spectralz_v4(...)`. So no python code
   in this repo changed; the fix flows in as a dependency bump.
-  Corresponding values-level difference: `encode_position(gs)`
-  and every `spectralz` file written by 0.3.3 are numerically
-  different from 0.3.2 for identical input positions, but the
-  determinism / round-trip / reproducibility-under-seed guarantees
-  our tests anchor on still hold.
+  Values-level impact: `encode_position(gs)` and every `spectralz`
+  file written by 0.3.3 are numerically different from 0.3.2 for
+  identical input positions, but the determinism / round-trip /
+  reproducibility-under-seed guarantees our tests anchor on still
+  hold (18/18 spectral tests pass under `chess-spectral` 1.2.3
+  without code changes).
 
 ### Changed
 
 - `[spectral]` extra: `chess-spectral>=1.1.3` →
-  `chess-spectral[corpus]>=1.2.2`. The `[corpus]` extra is a
-  **temporary workaround** — `chess-spectral` 1.2.2's
-  `__init__.py` eagerly imports `phase_operators.occupation_field`,
-  which does an unconditional `import chess` (the `python-chess`
-  2D library). 4D-only users hit
-  `ModuleNotFoundError: No module named 'chess'` on
-  `import chess_spectral` unless `python-chess` is present. The
-  `[corpus]` extra is upstream's sanctioned way to pull
-  `python-chess` as a transitive dep. When a future
-  `chess-spectral` release makes that import lazy, we'll drop
-  `[corpus]` from the line and the comment in `pyproject.toml`
-  explains the expected cleanup. Net cost to downstream: one extra
-  transitive wheel (`python-chess`, ≈2 MB) for now.
+  `chess-spectral>=1.2.3`. Covers **two** upstream changes landing
+  at once:
+
+  1. The B1/B2 character-table fix above (from 1.2.2).
+  2. A lazy-import fix (from 1.2.3) for
+     `phase_operators.occupation_field`, which `chess-spectral`
+     1.2.2's `__init__.py` eagerly imported — and which
+     unconditionally did `import chess` (the `python-chess` 2D
+     library). That regression meant 4D-only consumers briefly had
+     to pull `python-chess` transitively. 1.2.3 defers that import
+     until it's actually needed, so chess4d's `[spectral]` extra
+     now installs cleanly without `python-chess`. Pinning directly
+     at `>=1.2.3` lets us skip the `[corpus]` workaround entirely.
 
 ### Notes for research users
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-chess4d-oana-chiru"
-version = "0.3.2"
+version = "0.3.3"
 description = "Python reference implementation of Oana & Chiru (2026) — A Mathematical Framework for Four-Dimensional Chess (DOI 10.3390/appliedmath6030048)."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -46,12 +46,20 @@ dev = [
 ]
 spectral = [
     # chess-spectral — 45 056-dim 4D encoder + spectralz v4 frame format.
-    # Published to PyPI as ``chess-spectral``; 1.1.3 is the first (and
-    # currently only) PyPI release — the 1.1.1 and 1.1.2 iterations were
-    # internal packaging fixes before upload. Pinned at the current
-    # released lower bound so downstream resolves to a real PyPI version
-    # rather than hitting a "no matching distribution" error.
-    "chess-spectral>=1.1.3",
+    # Pinned at ``>=1.2.2`` to pick up the D₄×Z₂ B1/B2 character-table
+    # fix that lands there (see CHANGELOG [0.3.3]).
+    #
+    # The ``[corpus]`` extra is a **temporary workaround** for an
+    # upstream eager-import bug: 1.2.2's
+    # ``chess_spectral/__init__.py`` unconditionally imports
+    # ``phase_operators.occupation_field``, which in turn does
+    # ``import chess`` (the python-chess 2D library) at module load.
+    # So even 4D-only users hit ``ModuleNotFoundError: No module named
+    # 'chess'`` unless ``python-chess`` is present. ``[corpus]`` is
+    # upstream's sanctioned way to pull ``python-chess`` as a
+    # transitive. When a chess-spectral release makes that import
+    # lazy, drop ``[corpus]`` from this line.
+    "chess-spectral[corpus]>=1.2.2",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,20 +46,19 @@ dev = [
 ]
 spectral = [
     # chess-spectral — 45 056-dim 4D encoder + spectralz v4 frame format.
-    # Pinned at ``>=1.2.2`` to pick up the D₄×Z₂ B1/B2 character-table
-    # fix that lands there (see CHANGELOG [0.3.3]).
+    # Pinned at ``>=1.2.3`` to pick up two upstream changes at once:
     #
-    # The ``[corpus]`` extra is a **temporary workaround** for an
-    # upstream eager-import bug: 1.2.2's
-    # ``chess_spectral/__init__.py`` unconditionally imports
-    # ``phase_operators.occupation_field``, which in turn does
-    # ``import chess`` (the python-chess 2D library) at module load.
-    # So even 4D-only users hit ``ModuleNotFoundError: No module named
-    # 'chess'`` unless ``python-chess`` is present. ``[corpus]`` is
-    # upstream's sanctioned way to pull ``python-chess`` as a
-    # transitive. When a chess-spectral release makes that import
-    # lazy, drop ``[corpus]`` from this line.
-    "chess-spectral[corpus]>=1.2.2",
+    # 1. The D₄×Z₂ B1/B2 character-table correctness fix (landed in
+    #    1.2.2) — the bug that broke projector idempotence and
+    #    corrupted the B1/B2 channel contributions of the
+    #    45 056-dim 4D encoding. See CHANGELOG [0.3.3].
+    # 2. The lazy-import fix for ``phase_operators.occupation_field``
+    #    (landed in 1.2.3) — 1.2.2's ``chess_spectral/__init__.py``
+    #    eagerly imported that module, which unconditionally did
+    #    ``import chess`` (python-chess 2D library). 1.2.3 defers the
+    #    import until it's actually needed, so 4D-only consumers no
+    #    longer pay for a ``python-chess`` transitive dep.
+    "chess-spectral>=1.2.3",
 ]
 
 [project.scripts]

--- a/src/chess4d/spectral.py
+++ b/src/chess4d/spectral.py
@@ -32,11 +32,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Iterable, Iterator, Union
 
 try:
-    from chess_spectral.encoder_4d import (  # type: ignore[import-untyped]
+    # chess-spectral ≥ 1.2.2 ships a ``py.typed`` marker; the
+    # ``# type: ignore[import-untyped]`` comments the earlier pin
+    # needed are now rejected by mypy as unused, so they're gone.
+    from chess_spectral.encoder_4d import (
         ENCODING_DIM_4D,
         encode_4d,
     )
-    from chess_spectral.frame_4d import (  # type: ignore[import-untyped]
+    from chess_spectral.frame_4d import (
         Frame4D,
         read_spectralz_v4,
         write_spectralz_v4,


### PR DESCRIPTION
## Summary

**Correctness release.** `chess-spectral` ≤ 1.1.3 — which chess4d `0.3.0`–`0.3.2` all pinned — carried a bug in the D₄×Z₂ irrep projector character table: `B1` and `B2` used `[1, -1, 1, -1, 1, -1, 1, -1]` (inherited from an old chess convention with a different axis-vs-diagonal ordering), treating `g4`/`g5` (axis reflections, same conjugacy class) as opposite-signed. Characters must be constant on conjugacy classes, so the projector was **not idempotent** and the B1/B2-channel contributions to the 45 056-dim 4D encoding were **numerically wrong**.

Both relevant upstream fixes are now live:

- **`chess-spectral` 1.2.2** — the B1/B2 character-table correction.
- **`chess-spectral` 1.2.3** — makes `phase_operators.occupation_field` import lazy, so 4D-only consumers no longer pay for a `python-chess` transitive dep.

Pinning directly at `>=1.2.3` picks up both in one bump with no workaround.

## ⚠️ Research impact

Every `.spectralz` file and every `encode_position()` vector produced by chess4d `0.3.0` through `0.3.2` carries buggy projector output. Downstream analysis derived from those encodings should be considered suspect until re-encoded against `0.3.3`.

The upgrade path for existing corpora is painless because encoding is NDJSON-driven — no game replay needed:

```bash
pip install --upgrade "python-chess4d-oana-chiru[spectral]"
chess4d-corpus-encode ./corpus/<run_id>     # rewrites spectralz/ + manifest.json in place
```

`c4d` and NDJSON sidecars are unaffected by the projector fix.

## Changes

### Dependency bump

- `[spectral]` extra: `chess-spectral>=1.1.3` → `chess-spectral>=1.2.3`.
- No new transitive deps. `[spectral]` install closure stays `chess-spectral + numpy + scipy + chess4d`.

### Housekeeping

- `chess4d` 0.3.2 → 0.3.3.
- Dropped two now-unused `# type: ignore[import-untyped]` comments on `chess_spectral` imports in `chess4d/spectral.py` — `chess-spectral` 1.2.3 ships a `py.typed` marker, so mypy resolves the types directly.

### Docs

CHANGELOG's `[0.3.3]` entry explains the B1/B2 fix in detail (including the conjugacy-class verification `g1·g4·g1⁻¹ = g5`, `g1·g6·g1⁻¹ = g7` the upstream notebook used) and gives the retro-encode one-liner for affected users.

## No Python code changes (semantically)

chess4d's `chess4d.spectral` module is a thin adapter over `chess_spectral.encoder_4d.encode_4d` and `chess_spectral.frame_4d.*`. None of the D₄×Z₂ character-table / projector math lives in this repo, so the correctness fix flows in entirely via the dependency bump.

## Verified (re-run after 1.2.3 bump)

- [x] `tests/test_spectral.py`: **18/18 pass under `chess-spectral==1.2.3`** (our assertions anchor on determinism / round-trip / seed reproducibility, not specific encoder values — exactly the right abstraction for this kind of upstream correctness change)
- [x] `mypy --strict src/chess4d` clean
- [x] `ruff check src tests` clean
- [x] `python -m build` produces clean sdist + wheel; `twine check --strict` PASSED on both
- [x] Wheel METADATA: `Requires-Dist: chess-spectral>=1.2.3; extra == 'spectral'` (no `[corpus]`)
- [x] **Fresh venv → `pip install "python-chess4d-oana-chiru[spectral]"` closure contains only `chess-spectral==1.2.3` + `numpy` + `scipy` + `chess4d`**; `python-chess` confirmed absent. `encode_position(initial_position())` returns `(45056,) float32` with 21 030 nonzero entries.

## On merge

Autotag → `v0.3.3` tag + GitHub Release (with the CHANGELOG[0.3.3] body as release notes) → dispatches `publish-to-pypi.yml` → `python-chess4d-oana-chiru==0.3.3` lands on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)