### PR TITLE
Advertise Python 3.13 / 3.14 support in classifiers (0.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] — 2026-04-28
+
+Metadata-only patch release: advertise Python 3.13 and 3.14 support
+in the Trove classifiers. **No code changes.**
+
+### Changed
+
+- `pyproject.toml` `classifiers`: added
+  `"Programming Language :: Python :: 3.13"` and
+  `"Programming Language :: Python :: 3.14"`. The package itself is
+  pure-Python (`py3-none-any` wheel) and `requires-python = ">=3.11"`
+  already allowed both versions; this just teaches the PyPI project
+  page (and the README's `pyversions` shields.io badge) what we
+  actually support. End-to-end install verified on a fresh Python
+  3.14 venv — closure resolves to `chess-spectral 1.3.2 (cp314)`,
+  `numpy`, `scipy`, no `python-chess`, and `encode_position(
+  initial_position())` produces the expected `(45056,) float32`
+  with 21 030 nonzero entries.
+
 ## [0.4.0] — 2026-04-27
 
 **Native (C) encoder support.** chess4d can now route corpus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-chess4d-oana-chiru"
-version = "0.4.0"
+version = "0.4.1"
 description = "Python reference implementation of Oana & Chiru (2026) — A Mathematical Framework for Four-Dimensional Chess (DOI 10.3390/appliedmath6030048)."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -23,6 +23,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Games/Entertainment :: Board Games",
     "Topic :: Scientific/Engineering",


### PR DESCRIPTION
## Summary

Metadata-only patch release. Adds `Python :: 3.13` and `Python :: 3.14` to the Trove classifiers in `pyproject.toml`. **No code changes.**

## Why

The package is already pure-Python (`py3-none-any` wheel) and `requires-python = ">=3.11"` allows any 3.x ≥ 3.11. We've already verified end-to-end install on a fresh Python 3.14 venv during the 0.4.0 work:

- `chess-spectral 1.3.2` (cp314 wheel) + `numpy` + `scipy` resolve cleanly
- `encode_position(initial_position())` returns `(45056,) float32` with 21 030 nonzero
- No `python-chess` pulled in (1.2.3 lazy-import fix carries forward)

What was missing: the **classifiers metadata** that drives the PyPI project page's "Programming Language" facet AND the README's `pyversions` shields.io badge. Without 3.13/3.14 listed, the badge shows `3.11 | 3.12` even though we support 3.13 / 3.14 fine. This patch fixes that.

## Verified

- [x] `python -m build` + `twine check --strict`: PASSED on 0.4.1 sdist + wheel
- [x] Wheel METADATA carries all four `Programming Language :: Python :: 3.{11,12,13,14}` classifier lines
- [x] No code changes — same `py3-none-any` wheel content as 0.4.0 modulo version metadata

## On merge

Autotag → `v0.4.1` tag + GitHub Release → dispatches `publish-to-pypi.yml` → `python-chess4d-oana-chiru==0.4.1` lands on PyPI. Once it's live, the PyPI project page's "Programming Language" filter will list 3.13 and 3.14, and the README's `pyversions` badge will reflect the broader support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)