### PR TITLE
Correct first author name from Oana to Rinaldi-Unciuleanu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 This repo is **pre-implementation**. The working tree currently contains only:
 
 - `LICENSE` — Unlicense
-- `hoodoos/oana-chiru-2026.pdf` and `hoodoos/oana-chiru-2026.xml` — the source paper this project implements (Oana & Chiru, *A Mathematical Framework for Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026, DOI 10.3390/appliedmath6030048)
+- `hoodoos/oana-chiru-2026.pdf` and `hoodoos/oana-chiru-2026.xml` — the source paper this project implements (Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026, DOI 10.3390/appliedmath6030048). The MDPI metadata records the first author's surname as "Oana" with given names "Rinaldi (Unciuleanu)"; the actual family name is Rinaldi-Unciuleanu and "Oana" is a given name, hence the citation form above. The legacy `oana-chiru` slug is preserved only in filenames, the PyPI/dist name, and the GitHub repo URL because renaming those would break already-published artifacts.
 
 There is no Python package, no dependency manifest, no tests, no CI, and no README. Build/lint/test commands do not yet exist — do not invent them. When starting the implementation, establish the packaging choice (e.g. `pyproject.toml` + `pytest`) and update this file.
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,15 @@
 
 Python reference implementation of:
 
-> Oana & Chiru, *A Mathematical Framework for Four-Dimensional Chess*,
+> Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for Four-Dimensional Chess*,
 > MDPI AppliedMath **6**(3):48, 2026. DOI [10.3390/appliedmath6030048](https://doi.org/10.3390/appliedmath6030048).
 
-The source paper lives in `hoodoos/` (treat as read-only reference).
+The source paper lives in `hoodoos/` (treat as read-only reference). Note on
+naming: MDPI's metadata lists the first author's surname as "Oana" with given
+names "Rinaldi (Unciuleanu)", but the actual family name is Rinaldi-Unciuleanu;
+the `oana-chiru` slug survives in the PyPI/dist name, the GitHub repo URL, and
+a few paper-archive filenames because those are already published and cannot be
+renamed without breaking installs and external links.
 
 ## Install
 
@@ -57,8 +62,8 @@ notation with round-trip I/O, chess-spectral integration (optional),
 and a random-playout corpus generator writing the
 `chess-maths-the-movie` nested layout.
 
-Not yet implemented: search / evaluation, a UI, Oana-Chiru 4D-aware
-opening books. See `CLAUDE.md` for architectural invariants.
+Not yet implemented: search / evaluation, a UI, Rinaldi-Unciuleanu & Chiru
+4D-aware opening books. See `CLAUDE.md` for architectural invariants.
 
 ## Spectral encoding (optional)
 
@@ -94,7 +99,7 @@ write_spectralz("game.spectralz", start_state, move_list)
 ```
 
 The 11 channels cover the six piece types (with pawns split by forward
-axis per Oana & Chiru Def. 11) plus board-parity and side-to-move
+axis per Rinaldi-Unciuleanu & Chiru Def. 11) plus board-parity and side-to-move
 signals. See the `chess-spectral` notebooks in the mlehaptics repo for
 channel semantics and reconstruction examples.
 
@@ -170,7 +175,7 @@ move kernels — selecting it today raises `NotImplementedError`.
 `--seed N` seeds a **single `random.Random(N)`** instance that is
 **shared across every game in the run**. The only thing that RNG drives
 is the move choice (`rng.choice(legal_moves)`); the starting position
-is always the canonical Oana-Chiru §3.3 layout and is *not* seeded.
+is always the canonical Rinaldi-Unciuleanu & Chiru §3.3 layout and is *not* seeded.
 
 Because the RNG is deterministic, a corpus produced with a given
 `(max_plies, seed)` is actually an **infinite deterministic sequence**

--- a/benches/bench_legal_moves.py
+++ b/benches/bench_legal_moves.py
@@ -47,7 +47,7 @@ from chess4d import (
 
 
 def _initial_white() -> GameState:
-    """S1: the Oana-Chiru starting position; white to move."""
+    """S1: the Rinaldi-Unciuleanu & Chiru starting position; white to move."""
     return initial_position()
 
 

--- a/examples/encode_hello_4d.py
+++ b/examples/encode_hello_4d.py
@@ -1,6 +1,6 @@
 """Smoke example for the chess4d ⇄ chess-spectral adapter.
 
-Plays five random moves from the Oana-Chiru starting position, writes a
+Plays five random moves from the Rinaldi-Unciuleanu & Chiru starting position, writes a
 ``spectralz`` v4 file to ``hello.spectralz`` in the current directory,
 reads it back, and prints a one-line summary.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "python-chess4d-oana-chiru"
 version = "0.4.1"
-description = "Python reference implementation of Oana & Chiru (2026) — A Mathematical Framework for Four-Dimensional Chess (DOI 10.3390/appliedmath6030048)."
+description = "Python reference implementation of Rinaldi-Unciuleanu & Chiru (2026) — A Mathematical Framework for Four-Dimensional Chess (DOI 10.3390/appliedmath6030048)."
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "Unlicense" }

--- a/src/chess4d/__init__.py
+++ b/src/chess4d/__init__.py
@@ -1,8 +1,8 @@
-"""chess4d — Python reference implementation of Oana & Chiru (2026).
+"""chess4d — Python reference implementation of Rinaldi-Unciuleanu & Chiru (2026).
 
 Paper
 -----
-Oana & Chiru, *A Mathematical Framework for Four-Dimensional Chess*,
+Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for Four-Dimensional Chess*,
 MDPI AppliedMath 6(3):48, 2026. DOI 10.3390/appliedmath6030048.
 The source document lives at ``hoodoos/oana-chiru-2026.xml`` and is the
 authoritative spec for this package; section numbers referenced in

--- a/src/chess4d/corpus.py
+++ b/src/chess4d/corpus.py
@@ -59,7 +59,7 @@ Schema docs
 * NDJSON schema id: ``"chess4d-ndjson-v1"`` on line 1.
 * Manifest top-level keys: ``generated_utc``, ``run_id``, ``source``,
   ``fetch_params``, ``tool_versions``, ``aggregates``, ``games``.
-* Per-ply pos4 dict uses the v1.1.1 Oana-Chiru schema — 2-char pawn
+* Per-ply pos4 dict uses the v1.1.1 Rinaldi-Unciuleanu & Chiru schema — 2-char pawn
   values (``Pw``/``Py``/``pw``/``py``) and 1-char non-pawns.
 
 The ``[spectral]`` extra is only required when encoding is enabled;
@@ -168,7 +168,7 @@ def play_random_game(
     Stops at checkmate, stalemate, or ``max_plies``. The engine's
     full legality pipeline (§3.4 Def 3) is honored on every ply via
     :meth:`GameState.legal_moves`, so the resulting move list is
-    always a valid Oana-Chiru game prefix.
+    always a valid Rinaldi-Unciuleanu & Chiru game prefix.
     """
     gs = initial_position()
     moves: list[Move4D] = []
@@ -208,7 +208,7 @@ def _pos4_compact(gs: GameState) -> dict[str, str]:
     """Serialize the occupied board into a JSON-safe pos4 dict.
 
     Keys are the linear square index (``str(int)``), values follow the
-    v1.1.1 Oana-Chiru schema:
+    v1.1.1 Rinaldi-Unciuleanu & Chiru schema:
 
     * Pawns are two characters — ``P``/``p`` (white/black) followed by
       ``y``/``w`` (forward axis).
@@ -341,7 +341,7 @@ def read_ndjson_game(
     """Parse a ``chess4d-ndjson-v1`` file; return ``(start, moves, headers)``.
 
     The inverse of :func:`write_ndjson_game`. Assumes the file was
-    written from the standard Oana-Chiru :func:`initial_position` — the
+    written from the standard Rinaldi-Unciuleanu & Chiru :func:`initial_position` — the
     ply-0 ``pos4`` snapshot is validated against that starting
     configuration, and a ``ValueError`` is raised if it doesn't match
     (so a file written from a mid-game snapshot by some future producer

--- a/src/chess4d/errors.py
+++ b/src/chess4d/errors.py
@@ -1,6 +1,6 @@
 """Domain-specific exceptions for chess4d.
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 """

--- a/src/chess4d/geometry.py
+++ b/src/chess4d/geometry.py
@@ -1,6 +1,6 @@
 """Precomputed geometry for 4D move generation.
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 

--- a/src/chess4d/notation/__init__.py
+++ b/src/chess4d/notation/__init__.py
@@ -8,7 +8,7 @@ Serialization formats for moves, positions, and games:
 * :mod:`chess4d.notation.json_format` — machine-readable JSON for
   tooling and interchange (Format B).
 
-Neither Oana & Chiru nor any other published 4D-chess implementation
+Neither Rinaldi-Unciuleanu & Chiru nor any other published 4D-chess implementation
 ships a notation format; these are the reference formats for Python
 tooling around the chess4d package.
 

--- a/src/chess4d/pieces/_common.py
+++ b/src/chess4d/pieces/_common.py
@@ -1,6 +1,6 @@
 """Shared generators for sliding pieces (rook, bishop, queen).
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 

--- a/src/chess4d/spectral.py
+++ b/src/chess4d/spectral.py
@@ -12,7 +12,7 @@ Three public entry points::
     encode_game(start, moves)    -> iterator of (GameState, ndarray)
     write_spectralz(path, ...)   -> int bytes written, spectralz v4
 
-Pawn value convention follows the v1.1.1 Oana-Chiru schema documented
+Pawn value convention follows the v1.1.1 Rinaldi-Unciuleanu & Chiru schema documented
 on :func:`chess_spectral.encoder_4d.encode_4d`: pawns are emitted as
 ``(color_char, axis_char)`` tuples, never as bare single chars (the
 legacy form emits a ``DeprecationWarning`` and is avoided here).
@@ -92,9 +92,9 @@ def gamestate_to_pos4(gs: GameState) -> dict[int, PieceValue]:
     """Translate a :class:`GameState` into the encoder's ``pos4`` dict.
 
     Empty squares are omitted. Pawns are always emitted as
-    ``(color_char, axis_char)`` tuples per the v1.1.1 Oana-Chiru
-    schema; non-pawn pieces are single characters, uppercase for
-    White and lowercase for Black.
+    ``(color_char, axis_char)`` tuples per the v1.1.1
+    Rinaldi-Unciuleanu & Chiru schema; non-pawn pieces are single
+    characters, uppercase for White and lowercase for Black.
 
     Raises :class:`ValueError` for a pawn without a ``pawn_axis`` (the
     :class:`~chess4d.types.Piece` invariant should make this

--- a/src/chess4d/startpos.py
+++ b/src/chess4d/startpos.py
@@ -1,4 +1,4 @@
-"""Oana-Chiru starting position (paper §3.3).
+"""Rinaldi-Unciuleanu & Chiru starting position (paper §3.3).
 
 The initial position places 896 pieces across 64 ``(z, w)``-slices,
 partitioned into four classes:
@@ -133,7 +133,7 @@ def _initial_castling_rights() -> frozenset[CastlingRight]:
 
 
 def initial_position() -> GameState:
-    """Return the Oana-Chiru starting position with white to move.
+    """Return the Rinaldi-Unciuleanu & Chiru starting position with white to move.
 
     Populates the board with 896 pieces (448 per color, 28 kings per
     side) across the slice partition defined in :data:`CENTRAL_SLICES`,

--- a/src/chess4d/types.py
+++ b/src/chess4d/types.py
@@ -1,6 +1,6 @@
 """Core types for chess4d.
 
-All citations refer to Oana & Chiru, *A Mathematical Framework for
+All citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Shared pytest fixtures and Hypothesis strategies for chess4d.
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 """

--- a/tests/test_attacks.py
+++ b/tests/test_attacks.py
@@ -1,6 +1,6 @@
 """Attack-map tests (paper §3.4, Definition 2; §3.10 Definition 13).
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 

--- a/tests/test_bishop_adjacency.py
+++ b/tests/test_bishop_adjacency.py
@@ -1,6 +1,6 @@
 """Bishop-adjacency invariants (paper §3.7, §3.8).
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 

--- a/tests/test_bishop_moves.py
+++ b/tests/test_bishop_moves.py
@@ -1,6 +1,6 @@
 """Tests for :func:`chess4d.pieces.bishop.bishop_moves` (paper §3.7, §3.8).
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 """

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -1,6 +1,6 @@
 """Tests for :class:`Board4D` construction and piece-list primitives.
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 """

--- a/tests/test_castling.py
+++ b/tests/test_castling.py
@@ -1,6 +1,6 @@
 """Castling tests (paper §3.9 Def 10).
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 
@@ -8,7 +8,7 @@ Castling in 4D is restricted to the X-axis within a single ``(z, w)``
 -slice, but its *attack constraint is global*: every square the king
 traverses must be unattacked from any ``(z', w')`` slice. Rights-
 tracking follows standard chess, extended to 112 independent rights
-at the Oana-Chiru starting position (4+24 slices × 2 colors × 2 sides).
+at the Rinaldi-Unciuleanu & Chiru starting position (4+24 slices × 2 colors × 2 sides).
 """
 
 from __future__ import annotations

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -205,7 +205,7 @@ def test_ndjson_pos4_initial_counts(tmp_path: Path) -> None:
     for v in pawns:
         assert v[0] in ("P", "p")
         assert v[1] in ("y", "w")
-    # Non-pawn chars are the Oana-Chiru set, uppercase == white.
+    # Non-pawn chars are the Rinaldi-Unciuleanu & Chiru set, uppercase == white.
     for v in nonpawns:
         assert v in ("K", "Q", "R", "B", "N", "k", "q", "r", "b", "n")
 

--- a/tests/test_en_passant.py
+++ b/tests/test_en_passant.py
@@ -1,6 +1,6 @@
 """En-passant tests (paper §3.10 Def 15).
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 

--- a/tests/test_fifty_move.py
+++ b/tests/test_fifty_move.py
@@ -1,6 +1,6 @@
 """Halfmove-clock / 50-move-rule tests.
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048). The paper inherits FIDE's halfmove-
 clock semantics by reference.

--- a/tests/test_gamestate.py
+++ b/tests/test_gamestate.py
@@ -1,6 +1,6 @@
 """GameState tests (paper §3.4, Definitions 3-5).
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 

--- a/tests/test_king_adjacency.py
+++ b/tests/test_king_adjacency.py
@@ -1,6 +1,6 @@
 """King-adjacency invariants (paper §3.9, Definition 9; §3.2, Lemma 1).
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 

--- a/tests/test_king_moves.py
+++ b/tests/test_king_moves.py
@@ -1,6 +1,6 @@
 """Tests for :func:`chess4d.pieces.king.king_moves` (paper §3.9 Def 9).
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 

--- a/tests/test_knight_adjacency.py
+++ b/tests/test_knight_adjacency.py
@@ -1,6 +1,6 @@
 """Knight-adjacency invariants (paper §3.8, Definition 8, Theorem 3).
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 

--- a/tests/test_knight_moves.py
+++ b/tests/test_knight_moves.py
@@ -1,6 +1,6 @@
 """Tests for :func:`chess4d.pieces.knight.knight_moves` (paper §3.8).
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 

--- a/tests/test_legal_moves_parity.py
+++ b/tests/test_legal_moves_parity.py
@@ -10,7 +10,7 @@ exercises:
 * check patterns (single-checker, discovered-check-via-pinned-mover),
 * double-check (only king moves legal),
 * heavily-pinned positions,
-* multi-king scenes (Oana-Chiru has 28 kings per side initially),
+* multi-king scenes (Rinaldi-Unciuleanu & Chiru has 28 kings per side initially),
 * the Phase 5 feature-interaction smoke fixtures.
 
 Only a set-equality comparison matters: both paths yield fully legal

--- a/tests/test_legality.py
+++ b/tests/test_legality.py
@@ -1,6 +1,6 @@
 """Legality-filter tests (paper §3.4, Definitions 3-5, Remark 1).
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 

--- a/tests/test_pawn_adjacency.py
+++ b/tests/test_pawn_adjacency.py
@@ -1,6 +1,6 @@
 """Pawn geometry-table invariants (paper §3.10, Definitions 11-14).
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -1,6 +1,6 @@
 """Tests for :class:`Square4D` primitives.
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 """

--- a/tests/test_push_pop.py
+++ b/tests/test_push_pop.py
@@ -1,6 +1,6 @@
 """Tests for :meth:`Board4D.push` / :meth:`Board4D.pop`.
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 

--- a/tests/test_queen_adjacency.py
+++ b/tests/test_queen_adjacency.py
@@ -1,6 +1,6 @@
 """Queen-adjacency invariants (paper §3.8, Definition 7).
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 

--- a/tests/test_queen_moves.py
+++ b/tests/test_queen_moves.py
@@ -1,6 +1,6 @@
 """Tests for :func:`chess4d.pieces.queen.queen_moves` (paper §3.8 Def 7).
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 

--- a/tests/test_rook_adjacency.py
+++ b/tests/test_rook_adjacency.py
@@ -1,6 +1,6 @@
 """Rook-adjacency invariants (paper §3.5).
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 

--- a/tests/test_rook_moves.py
+++ b/tests/test_rook_moves.py
@@ -1,6 +1,6 @@
 """Tests for :func:`chess4d.pieces.rook.rook_moves` (paper §3.5, §3.8).
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 """

--- a/tests/test_startpos.py
+++ b/tests/test_startpos.py
@@ -1,6 +1,6 @@
 """Starting-position tests (paper §3.3).
 
-Citations refer to Oana & Chiru, *A Mathematical Framework for
+Citations refer to Rinaldi-Unciuleanu & Chiru, *A Mathematical Framework for
 Four-Dimensional Chess*, MDPI AppliedMath 6(3):48, 2026
 (DOI 10.3390/appliedmath6030048).
 


### PR DESCRIPTION
## Summary
Updates documentation to correctly attribute the paper's first author as Rinaldi-Unciuleanu & Chiru, rather than Oana & Chiru. Includes clarification on the naming discrepancy between MDPI's metadata and the actual author's family name.

## Changes
- Updated all paper citations in README.md and CLAUDE.md to use "Rinaldi-Unciuleanu & Chiru" instead of "Oana & Chiru"
- Added explanatory note in README.md clarifying that MDPI's metadata lists the first author's surname as "Oana" with given names "Rinaldi (Unciuleanu)", but the actual family name is Rinaldi-Unciuleanu
- Documented that the legacy `oana-chiru` slug is preserved in PyPI/dist names, GitHub repo URL, and paper-archive filenames to avoid breaking already-published artifacts and external links
- Updated CLAUDE.md with the same clarification about the author name discrepancy

## Notes
The `oana-chiru` slug remains in package names and repository identifiers for backward compatibility with published artifacts. Only the human-facing documentation has been corrected to reflect the proper author attribution.

https://claude.ai/code/session_01RVWokwZUS8vXxdPE4oLV3C